### PR TITLE
go: bump version to 1.18

### DIFF
--- a/.github/workflows/golangci-lint.yml.diabled
+++ b/.github/workflows/golangci-lint.yml.diabled
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.1.0

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -46,10 +46,13 @@ go_test(
         "doc_test.go",
         "encoder_test.go",
         "example_test.go",
+        "reader_fuzz_test.go",
         "reader_test.go",
+        "seekable_fuzz_test.go",
         "seekable_test.go",
         "writer_test.go",
     ],
+    data = glob(["testdata/**"]),
     embed = [":zstd-seekable-format-go"],
     race = "on",
     deps = [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,7 +13,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.17.8")
+go_register_toolchains(version = "1.18")
 
 http_archive(
     name = "bazel_gazelle",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SaveTheRbtz/zstd-seekable-format-go
 
-go 1.17
+go 1.18
 
 require (
 	github.com/cespare/xxhash v1.1.0

--- a/reader_fuzz_test.go
+++ b/reader_fuzz_test.go
@@ -1,0 +1,97 @@
+//go:build go1.18
+// +build go1.18
+
+package seekable
+
+import (
+	"io"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+)
+
+func FuzzReader(f *testing.F) {
+	dec, err := zstd.NewReader(nil)
+	assert.NoError(f, err)
+
+	f.Add(noChecksum, int64(0), uint8(1), io.SeekStart)
+	f.Add(checksum, int64(-1), uint8(2), io.SeekEnd)
+	f.Add(checksum, int64(1), uint8(0), io.SeekCurrent)
+
+	f.Fuzz(func(t *testing.T, in []byte, off int64, l uint8, whence int) {
+		sr := &seekableBufferReader{buf: in}
+		r, err := NewReader(sr, dec)
+		if err != nil {
+			return
+		}
+
+		i, err := r.Seek(off, whence)
+		if err != nil {
+			return
+		}
+
+		if l > 1<<6 {
+			l = 1 << 6
+		}
+		buf1 := make([]byte, l)
+
+		n, err := r.Read(buf1)
+		if err != nil && err != io.EOF {
+			return
+		}
+
+		buf2 := make([]byte, n)
+		m, err := r.ReadAt(buf2, i)
+		// t.Logf("off: %d, l: %d, whence: %d, i: %d, n: %d, m: %d", off, l, whence, i, n, m)
+
+		if err != io.EOF {
+			assert.NoError(t, err)
+		}
+
+		assert.Equal(t, m, n)
+		assert.Equal(t, buf1[:n], buf2)
+	})
+}
+
+func FuzzReaderConst(f *testing.F) {
+	f.Add(int64(0), uint8(1), int8(io.SeekStart))
+	dec, err := zstd.NewReader(nil)
+	assert.NoError(f, err)
+
+	sr := &seekableBufferReader{buf: checksum}
+	r, err := NewReader(sr, dec)
+	assert.NoError(f, err)
+
+	f.Fuzz(func(t *testing.T, off int64, l uint8, whence int8) {
+		i, err := r.Seek(off, int(whence))
+		if err != nil {
+			return
+		}
+
+		if l > 1<<6 {
+			l = 1 << 6
+		}
+		buf1 := make([]byte, l)
+
+		n, err := r.Read(buf1)
+		if err != nil && err != io.EOF {
+			return
+		}
+
+		buf2 := make([]byte, n)
+		m, err := r.ReadAt(buf2, i)
+		// t.Logf("off: %d, l: %d, whence: %d, i: %d, n: %d, m: %d", off, l, whence, i, n, m)
+
+		if err != io.EOF {
+			assert.NoError(t, err)
+		}
+
+		assert.Equal(t, m, n)
+		assert.Equal(t, buf1[:n], buf2)
+
+		if n > 0 {
+			assert.Equal(t, string(buf2), sourceString[i:i+int64(n)])
+		}
+	})
+}

--- a/seekable_fuzz_test.go
+++ b/seekable_fuzz_test.go
@@ -1,0 +1,87 @@
+//go:build go1.18
+// +build go1.18
+
+package seekable
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+)
+
+func FuzzRoundTrip(f *testing.F) {
+	dec, err := zstd.NewReader(nil)
+	assert.NoError(f, err)
+	defer dec.Close()
+
+	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
+	assert.NoError(f, err)
+	defer enc.Close()
+
+	f.Add(int64(1), uint8(0), int16(1), int8(io.SeekStart))
+	f.Add(int64(10), uint8(1), int16(2), int8(io.SeekEnd))
+	f.Add(int64(111), uint8(2), int16(3), int8(io.SeekCurrent))
+
+	f.Fuzz(func(t *testing.T, seed int64, frames uint8, l int16, whence int8) {
+		var b bytes.Buffer
+		bufWriter := bufio.NewWriter(&b)
+
+		w, err := NewWriter(bufWriter, enc)
+		assert.NoError(t, err)
+
+		total := int16(0)
+		rng := rand.New(rand.NewSource(seed))
+		for i := 0; i < int(frames); i++ {
+			sz := rng.Int63n(100)
+			total += int16(sz)
+
+			rndBuf := make([]byte, sz)
+
+			_, err := rng.Read(rndBuf)
+			assert.NoError(t, err)
+
+			_, err = w.Write(rndBuf)
+			assert.NoError(t, err)
+		}
+		err = w.Close()
+		assert.NoError(t, err)
+
+		err = bufWriter.Flush()
+		assert.NoError(t, err)
+
+		r, err := NewReader(bytes.NewReader(b.Bytes()), dec)
+		assert.NoError(t, err)
+
+		off := rng.Int63n(1+4*int64(total)) - 2*int64(total)
+		i, err := r.Seek(off, int(whence))
+		if err != nil {
+			return
+		}
+
+		if l > total || l < 0 {
+			l = total
+		}
+		buf1 := make([]byte, l)
+
+		n, err := r.Read(buf1)
+		if err != nil && err != io.EOF {
+			return
+		}
+
+		buf2 := make([]byte, n)
+		m, err := r.ReadAt(buf2, i)
+		// t.Logf("off: %d, l: %d, whence: %d, i: %d, n: %d, m: %d", off, l, whence, i, n, m)
+
+		if err != io.EOF {
+			assert.NoError(t, err)
+		}
+
+		assert.Equal(t, m, n)
+		assert.Equal(t, buf1[:n], buf2)
+	})
+}


### PR DESCRIPTION
golangci-lint is blocked on https://github.com/golangci/golangci-lint/pull/2438