### PR TITLE
reader: add io.Closer to the interface     

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//options",
         "@com_github_cespare_xxhash_v2//:xxhash",
         "@com_github_google_btree//:btree",
+        "@org_uber_go_atomic//:atomic",
         "@org_uber_go_multierr//:multierr",
         "@org_uber_go_zap//:zap",
         "@org_uber_go_zap//zapcore",

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ r, err := seekable.NewReader(f, dec)
 if err != nil {
 	log.Fatal(err)
 }
+defer r.Close()
 
 ello := make([]byte, 4)
 // ReaderAt

--- a/decoder.go
+++ b/decoder.go
@@ -1,6 +1,8 @@
 package seekable
 
 import (
+	"io"
+
 	"github.com/google/btree"
 
 	"github.com/SaveTheRbtz/zstd-seekable-format-go/env"
@@ -22,6 +24,8 @@ type Decoder interface {
 
 	// NumFrames returns number of frames in the compressed stream.
 	NumFrames() int64
+
+	io.Closer
 }
 
 // NewDecoder creates a byte-oriented Decode interface from a given seektable index.

--- a/decoder.go
+++ b/decoder.go
@@ -1,8 +1,6 @@
 package seekable
 
 import (
-	"io"
-
 	"github.com/google/btree"
 
 	"github.com/SaveTheRbtz/zstd-seekable-format-go/env"
@@ -25,7 +23,8 @@ type Decoder interface {
 	// NumFrames returns number of frames in the compressed stream.
 	NumFrames() int64
 
-	io.Closer
+	// Close closes the decoder feeing up any resources.
+	Close() error
 }
 
 // NewDecoder creates a byte-oriented Decode interface from a given seektable index.

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -12,9 +12,11 @@ func TestDecoder(t *testing.T) {
 
 	dec, err := zstd.NewReader(nil)
 	assert.NoError(t, err)
+	defer dec.Close()
 
 	d, err := NewDecoder(checksum[17+18:], dec)
 	assert.NoError(t, err)
+	defer func() { assert.NoError(t, d.Close())}()
 
 	assert.Equal(t, int64(len(sourceString)), d.Size())
 	assert.Equal(t, int64(2), d.NumFrames())

--- a/encoder.go
+++ b/encoder.go
@@ -14,6 +14,7 @@ import (
 type Encoder interface {
 	// Encode returns compressed data and appends a frame to in-memory seek table.
 	Encode(src []byte) ([]byte, error)
+
 	// EndStream returns in-memory seek table as a ZSTD's skippable frame.
 	EndStream() ([]byte, error)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -53,6 +53,7 @@ func Example() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer r.Close()
 
 	ello := make([]byte, 4)
 	// ReaderAt

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/klauspost/compress v1.15.1
 	github.com/restic/chunker v0.4.0
 	github.com/stretchr/testify v1.7.1
+	go.uber.org/atomic v1.9.0
 	go.uber.org/multierr v1.8.0
 	go.uber.org/zap v1.21.0
 )
@@ -15,6 +16,5 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/reader.go
+++ b/reader.go
@@ -288,10 +288,6 @@ func (r *readerImpl) read(dst []byte, off int64) (int64, int, error) {
 }
 
 func (r *readerImpl) Seek(offset int64, whence int) (int64, error) {
-	if r.closed.Load() {
-		return 0, fmt.Errorf("reader is closed")
-	}
-
 	newOffset := r.offset
 	switch whence {
 	case io.SeekCurrent:

--- a/reader.go
+++ b/reader.go
@@ -124,20 +124,20 @@ type Reader interface {
 	// Seek implements io.Seeker interface to randomly access data.
 	// This method is NOT goroutine-safe and CAN NOT be called
 	// concurrently since it modifies the underlying offset.
-	io.Seeker
+	Seek(offset int64, whence int) (int64, error)
 
 	// Read implements io.Reader interface to sequentially access data.
 	// This method is NOT goroutine-safe and CAN NOT be called
 	// concurrently since it modifies the underlying offset.
-	io.Reader
+	Read(p []byte) (n int, err error)
 
 	// ReadAt implements io.ReaderAt interface to randomly access data.
 	// This method is goroutine-safe and can be called concurrently ONLY if
 	// the underlying reader supports io.ReaderAt interface.
-	io.ReaderAt
+	ReadAt(p []byte, off int64) (n int, err error)
 
 	// Close implements io.Closer interface free up any resources.
-	io.Closer
+	Close() error
 }
 
 // ZSTDDecoder is the decompressor.  Tested with github.com/klauspost/compress/zstd.

--- a/reader_test.go
+++ b/reader_test.go
@@ -178,6 +178,15 @@ func TestReader(t *testing.T) {
 
 		_, err = r.Read(tmp)
 		assert.Equal(t, err, io.EOF)
+
+		err = r.Close()
+		assert.NoError(t, err)
+
+		// read after close
+		_, err = r.Read(tmp)
+		assert.ErrorContains(t, err, "reader is closed")
+
+		// double close
 		err = r.Close()
 		assert.NoError(t, err)
 	}

--- a/seekable_fuzz_test.go
+++ b/seekable_fuzz_test.go
@@ -21,7 +21,7 @@ func FuzzRoundTrip(f *testing.F) {
 
 	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
 	assert.NoError(f, err)
-	defer enc.Close()
+	defer func() { assert.NoError(f, enc.Close()) }()
 
 	f.Add(int64(1), uint8(0), int16(1), int8(io.SeekStart))
 	f.Add(int64(10), uint8(1), int16(2), int8(io.SeekEnd))
@@ -56,6 +56,7 @@ func FuzzRoundTrip(f *testing.F) {
 
 		r, err := NewReader(bytes.NewReader(b.Bytes()), dec)
 		assert.NoError(t, err)
+		defer func() { assert.NoError(t, r.Close()) }()
 
 		off := rng.Int63n(1+4*int64(total)) - 2*int64(total)
 		i, err := r.Seek(off, int(whence))

--- a/writer.go
+++ b/writer.go
@@ -42,12 +42,13 @@ type Writer interface {
 	//
 	// Note that Write does not do any coalescing nor splitting of data,
 	// so each write will map to a separate ZSTD Frame.
-	io.Writer
+	Write(src []byte) (int, error)
+
 	// Close implement io.Closer interface.  It writes the seek table footer
 	// and releases occupied memory.
 	//
 	// Caller is still responsible to Close the underlying writer.
-	io.Closer
+	Close() (err error)
 }
 
 // ZSTDEncoder is the compressor.  Tested with github.com/klauspost/compress/zstd.


### PR DESCRIPTION
This would allow implementing background work (e.g. Caches and Prefetch).