### PR TITLE
go: switch to using go.work for development

### DIFF
--- a/cmd/zstdseek/go.mod
+++ b/cmd/zstdseek/go.mod
@@ -2,11 +2,9 @@ module github.com/SaveTheRbtz/zstd-seekable-format-go/cmd/zstdseek
 
 go 1.22
 
-replace github.com/SaveTheRbtz/zstd-seekable-format-go/pkg => ../../pkg
-
 require (
 	github.com/SaveTheRbtz/fastcdc-go v0.3.0
-	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.0.0-00010101000000-000000000000
+	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.0.0-20240727192458-ceaa236e14f4
 	github.com/klauspost/compress v1.17.9
 	github.com/schollz/progressbar/v3 v3.14.4
 	go.uber.org/zap v1.27.0

--- a/cmd/zstdseek/go.sum
+++ b/cmd/zstdseek/go.sum
@@ -1,5 +1,7 @@
 github.com/SaveTheRbtz/fastcdc-go v0.3.0 h1:JdHvLlnijDuisYIwpRDcHZEjbxvCqtEmJ3gf35VJBgA=
 github.com/SaveTheRbtz/fastcdc-go v0.3.0/go.mod h1:2kMKqvBv1h9wCaUfETqsVkSESsCiFhp4YyEHyz7/SfE=
+github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.0.0-20240727192458-ceaa236e14f4 h1:fikBxIUc1RAVoAl8RYk/S8xbfaUgV7GyrndMrmmwUTk=
+github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.0.0-20240727192458-ceaa236e14f4/go.mod h1:JitQWJ8JuV4Y87l8VsHiiwhb3cgdyn68mX40s7NT6PA=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This would fix `go install`

Fixes: https://github.com/SaveTheRbtz/zstd-seekable-format-go/issues/144