### PR TITLE
Specify const types to support 32-bit arch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,7 @@ jobs:
           go get .
       - name: go work
         run: |
-          if [ "${{ matrix.dir }} " == "pkg" ]; then
+          if [ "${{ matrix.dir }}" == "pkg" ]; then
             echo "Skipping go workspace for ${{ matrix.dir }}"
             rm -f go.work*
             exit 0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,12 @@ jobs:
           go get .
       - name: Build (${{ matrix.dir }})
         working-directory: ./${{ matrix.dir }}
-        run: go build -v ./...
+        run: |
+          for OSARCH in $(go tool dist list); do
+            IFS="/" read -r OS ARCH <<< "$OSARCH"
+            echo "Building for $OS $ARCH"
+            GOOS=$OS GOARCH=$ARCH go build ./...
+          done
       - name: Test (${{ matrix.dir }})
         working-directory: ./${{ matrix.dir }}
         run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,13 +27,31 @@ jobs:
         working-directory: ./${{ matrix.dir }}
         run: |
           go get .
+      - name: go work
+        run: |
+          if [ "${{ matrix.dir }} " == "pkg" ]; then
+            echo "Skipping go workspace for ${{ matrix.dir }}"
+            rm -f go.work*
+            exit 0
+          fi
+          go work init
+          go work use pkg
+          go work use ${{ matrix.dir }}
       - name: Build (${{ matrix.dir }})
         working-directory: ./${{ matrix.dir }}
         run: |
           for OSARCH in $(go tool dist list); do
+            case $OSARCH in
+              freebsd*|darwin*|linux*|windows*|wasip*) ;;
+              *) continue ;;
+            esac
+            case $OSARCH in
+              *arm64|*arm|*amd64|*386|*riscv64|*wasm) ;;
+              *) continue ;;
+            esac
             IFS="/" read -r OS ARCH <<< "$OSARCH"
             echo "Building for $OS $ARCH"
-            CGO_ENABLED=1 GOOS=$OS GOARCH=$ARCH go build ./...
+            GOOS=$OS GOARCH=$ARCH go build ./...
           done
       - name: Test (${{ matrix.dir }})
         working-directory: ./${{ matrix.dir }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,7 +33,7 @@ jobs:
           for OSARCH in $(go tool dist list); do
             IFS="/" read -r OS ARCH <<< "$OSARCH"
             echo "Building for $OS $ARCH"
-            GOOS=$OS GOARCH=$ARCH go build ./...
+            CGO_ENABLED=1 GOOS=$OS GOARCH=$ARCH go build ./...
           done
       - name: Test (${{ matrix.dir }})
         working-directory: ./${{ matrix.dir }}

--- a/pkg/encoder.go
+++ b/pkg/encoder.go
@@ -55,9 +55,9 @@ func (s *writerImpl) Encode(src []byte) ([]byte, error) {
 }
 
 func (s *writerImpl) EndStream() ([]byte, error) {
-	if int64(len(s.frameEntries)) > maxChunkSize {
+	if int64(len(s.frameEntries)) > maxNumberOfFrames {
 		return nil, fmt.Errorf("number of frames for seekable format: %d > %d",
-			len(s.frameEntries), maxChunkSize)
+			len(s.frameEntries), maxNumberOfFrames)
 	}
 
 	seekTable := make([]byte, len(s.frameEntries)*12+9)

--- a/pkg/seekable.go
+++ b/pkg/seekable.go
@@ -50,7 +50,11 @@ const (
 
 	seekableTag = 0xE
 
+	// maximum size of a single frame
 	maxChunkSize int64 = math.MaxUint32
+
+	// maximum number of frames in a seekable stream
+	maxNumberOfFrames int64 = math.MaxUint32
 )
 
 /*

--- a/pkg/seekable.go
+++ b/pkg/seekable.go
@@ -36,9 +36,9 @@ const (
 
 		https://github.com/facebook/zstd/blob/dev/contrib/seekable_format/zstd_seekable_compression_format.md
 	*/
-	skippableFrameMagic = 0x184D2A50
+	skippableFrameMagic uint32 = 0x184D2A50
 
-	seekableMagicNumber = 0x8F92EAB1
+	seekableMagicNumber uint32 = 0x8F92EAB1
 
 	seekTableFooterOffset = 9
 
@@ -49,6 +49,8 @@ const (
 	maxDecoderFrameSize = 128 << 20
 
 	seekableTag = 0xE
+
+	maxChunkSize int64 = math.MaxUint32
 )
 
 /*
@@ -234,7 +236,7 @@ func createSkippableFrame(tag uint32, payload []byte) ([]byte, error) {
 		return nil, fmt.Errorf("requested tag (%d) > 0xf", tag)
 	}
 
-	if len(payload) > math.MaxUint32 {
+	if int64(len(payload)) > maxChunkSize {
 		return nil, fmt.Errorf("requested skippable frame size (%d) > max uint32", len(payload))
 	}
 


### PR DESCRIPTION
Fix #146.

On 386 arch, the bits length of the int type is 32, which makes it impossible to store or compare with math.MaxUint32 or `0x8F92EAB1`.

Go will implicitly use the int type, like the returned type of `len()`; And convert untyped const integer to the int type, like the input type of `fmt.Errorf()`.

