### PR TITLE
chore(tests): cleanup assert/require

### DIFF
--- a/pkg/decoder_test.go
+++ b/pkg/decoder_test.go
@@ -5,18 +5,19 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDecoder(t *testing.T) {
 	t.Parallel()
 
 	dec, err := zstd.NewReader(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer dec.Close()
 
 	d, err := NewDecoder(checksum[17+18:], dec)
-	assert.NoError(t, err)
-	defer func() { assert.NoError(t, d.Close()) }()
+	require.NoError(t, err)
+	defer func() { require.NoError(t, d.Close()) }()
 
 	assert.Equal(t, int64(len(sourceString)), d.Size())
 	assert.Equal(t, int64(2), d.NumFrames())
@@ -25,17 +26,17 @@ func TestDecoder(t *testing.T) {
 
 	bytes1 := []byte("test")
 	for _, off := range []uint64{0, 1, 3} {
-		index_off_0 := d.GetIndexByDecompOffset(off)
-		index_id_0 := d.GetIndexByID(0)
-		assert.Equal(t, index_off_0, index_id_0)
-		assert.NotEqual(t, index_off_0, nil)
-		assert.Equal(t, int64(0), index_off_0.ID)
-		assert.Equal(t, uint32(len(bytes1)), index_off_0.DecompSize)
-		assert.NotEqual(t, uint32(0), index_off_0.Checksum)
+		indexOff0 := d.GetIndexByDecompOffset(off)
+		indexID0 := d.GetIndexByID(0)
+		assert.Equal(t, indexOff0, indexID0)
+		assert.NotNil(t, indexOff0)
+		assert.Equal(t, int64(0), indexOff0.ID)
+		assert.Equal(t, uint32(len(bytes1)), indexOff0.DecompSize)
+		assert.NotEqual(t, uint32(0), indexOff0.Checksum)
 
 		decomp, err := dec.DecodeAll(
-			checksum[index_off_0.CompOffset:index_off_0.CompOffset+uint64(index_off_0.CompSize)], nil)
-		assert.NoError(t, err)
+			checksum[indexOff0.CompOffset:indexOff0.CompOffset+uint64(indexOff0.CompSize)], nil)
+		require.NoError(t, err)
 		assert.Equal(t, decomp, bytes1)
 	}
 
@@ -43,17 +44,17 @@ func TestDecoder(t *testing.T) {
 
 	bytes2 := []byte("test2")
 	for _, off := range []uint64{4, 5, 8} {
-		index_off_1 := d.GetIndexByDecompOffset(off)
-		index_id_1 := d.GetIndexByID(1)
-		assert.Equal(t, index_off_1, index_id_1)
-		assert.NotEqual(t, index_off_1, nil)
-		assert.Equal(t, int64(1), index_off_1.ID)
-		assert.Equal(t, uint32(len(bytes2)), index_off_1.DecompSize)
-		assert.NotEqual(t, uint32(0), index_off_1.Checksum)
+		indexOff1 := d.GetIndexByDecompOffset(off)
+		indexID1 := d.GetIndexByID(1)
+		assert.Equal(t, indexOff1, indexID1)
+		assert.NotNil(t, indexOff1)
+		assert.Equal(t, int64(1), indexOff1.ID)
+		assert.Equal(t, uint32(len(bytes2)), indexOff1.DecompSize)
+		assert.NotEqual(t, uint32(0), indexOff1.Checksum)
 
 		decomp, err := dec.DecodeAll(
-			checksum[index_off_1.CompOffset:index_off_1.CompOffset+uint64(index_off_1.CompSize)], nil)
-		assert.NoError(t, err)
+			checksum[indexOff1.CompOffset:indexOff1.CompOffset+uint64(indexOff1.CompSize)], nil)
+		require.NoError(t, err)
 		assert.Equal(t, decomp, bytes2)
 	}
 

--- a/pkg/encoder_test.go
+++ b/pkg/encoder_test.go
@@ -5,40 +5,41 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEncoder(t *testing.T) {
 	t.Parallel()
 
 	enc, err := zstd.NewWriter(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	e, err := NewEncoder(enc)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	decBytes1 := sourceString[:4]
 	encBytes1, err := e.Encode([]byte(decBytes1))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	decBytes2 := sourceString[4:]
 	encBytes2, err := e.Encode([]byte(decBytes2))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	footer, err := e.EndStream()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Standard Reader.
 	dec, err := zstd.NewReader(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	combined := append(append([]byte{}, encBytes1...), encBytes2...)
 	decompressed, err := dec.DecodeAll(combined, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, sourceString, string(decompressed))
 
 	// Seekable Decoder.
 	d, err := NewDecoder(footer, dec)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, int64(len(sourceString)), d.Size())
 	assert.Equal(t, int64(2), d.NumFrames())

--- a/pkg/seekable_test.go
+++ b/pkg/seekable_test.go
@@ -23,7 +23,7 @@ func TestCreateSkippableFrame(t *testing.T) {
 	t.Parallel()
 
 	dec, err := zstd.NewReader(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for i, tab := range []bytesErr{
 		{
@@ -51,7 +51,7 @@ func TestCreateSkippableFrame(t *testing.T) {
 			if tab.expectedErr == nil && err == nil {
 				assert.Equal(t, tab.expectedBytes, actualBytes, "createSkippableFrame output does not match expected")
 				decodedeBytes, err := dec.DecodeAll(actualBytes, nil)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, []byte(nil), decodedeBytes)
 			}
 		})
@@ -62,7 +62,7 @@ func TestIntercompat(t *testing.T) {
 	t.Parallel()
 
 	dec, err := zstd.NewReader(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, fn := range []string{
 		// t2sz README.md -l 22 -s 1024 -o intercompat-t2sz.zst
@@ -81,25 +81,25 @@ func TestIntercompat(t *testing.T) {
 			defer f.Close()
 
 			r, err := NewReader(f, dec)
-			assert.NoError(t, err)
-			defer func() { assert.NoError(t, r.Close()) }()
+			require.NoError(t, err)
+			defer func() { require.NoError(t, r.Close()) }()
 
 			buf := make([]byte, 4000)
 			n, err := r.Read(buf)
-			assert.NoError(t, err)
-			assert.Equal(t, n, 1024)
+			require.NoError(t, err)
+			assert.Equal(t, 1024, n)
 			assert.Equal(t, []byte("  [![License]"), buf[:13])
 
 			all, err := io.ReadAll(r)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Greater(t, len(all), 1024)
 
 			i, err := r.Seek(-47, io.SeekEnd)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Greater(t, i, int64(1024))
 
 			n, err = r.ReadAt(buf, i)
-			assert.ErrorIs(t, err, io.EOF)
+			require.ErrorIs(t, err, io.EOF)
 			assert.Equal(t, 47, n)
 			assert.Equal(t, []byte("[license]: https://opensource.org/licenses/MIT\n"), buf[:n])
 		})

--- a/pkg/testdata/fuzz/FuzzRoundTrip/4c7e5250c36d4db0
+++ b/pkg/testdata/fuzz/FuzzRoundTrip/4c7e5250c36d4db0
@@ -1,0 +1,5 @@
+go test fuzz v1
+int64(1)
+byte(',')
+int16(1)
+int8(0)

--- a/pkg/writer_test.go
+++ b/pkg/writer_test.go
@@ -10,42 +10,43 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriter(t *testing.T) {
 	t.Parallel()
 
 	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var b bytes.Buffer
 	bw := io.Writer(&b)
 	w, err := NewWriter(bw, enc)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	bytes1 := []byte("test")
 	bytesWritten1, err := w.Write(bytes1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	bytes2 := []byte("test2")
 	bytesWritten2, err := w.Write(bytes2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// test internals
 	sw := w.(*writerImpl)
-	assert.Equal(t, 2, len(sw.frameEntries))
-	assert.Equal(t, uint32(len(bytes1)), sw.frameEntries[0].DecompressedSize)
-	assert.Equal(t, bytesWritten1, len(bytes1))
+	assert.Len(t, sw.frameEntries, 2)
+	assert.Len(t, bytes1, int(sw.frameEntries[0].DecompressedSize))
+	assert.Len(t, bytes1, bytesWritten1)
 	assert.Equal(t, uint32(len(bytes2)), sw.frameEntries[1].DecompressedSize)
 	assert.Equal(t, uint32(bytesWritten2), sw.frameEntries[1].DecompressedSize)
 
 	index1CompressedSize := sw.frameEntries[0].CompressedSize
 	err = w.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify buffer content
 	buf := b.Bytes()
 	// magic footer
-	assert.Equal(t, buf[len(buf)-4:], []byte{0xb1, 0xea, 0x92, 0x8f})
+	assert.Equal(t, []byte{0xb1, 0xea, 0x92, 0x8f}, buf[len(buf)-4:])
 	assert.Equal(t, uint32(2), binary.LittleEndian.Uint32(buf[len(buf)-9:len(buf)-5]))
 	// index.1
 	indexOffset := len(buf) - 4 - 1 - 4 - 2*12
@@ -53,16 +54,17 @@ func TestWriter(t *testing.T) {
 	assert.Equal(t, uint32(len(bytes1)), binary.LittleEndian.Uint32(buf[indexOffset+4:indexOffset+8]))
 	// skipframe header
 	frameOffset := indexOffset - 4 - 4
-	assert.Equal(t, buf[frameOffset:frameOffset+4], []byte{0x5e, 0x2a, 0x4d, 0x18})
+	assert.Equal(t, []byte{0x5e, 0x2a, 0x4d, 0x18}, buf[frameOffset:frameOffset+4])
 	assert.Equal(t, uint32(0x21), binary.LittleEndian.Uint32(buf[frameOffset+4:frameOffset+8]))
 
 	// test decompression
 	br := io.Reader(&b)
 	dec, err := zstd.NewReader(br)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	readBuf := make([]byte, 1024)
 	n, err := dec.Read(readBuf)
-	assert.Equal(t, err, io.EOF)
+	require.ErrorIs(t, err, io.EOF)
+
 	concat := append(bytes1, bytes2...)
 	assert.Equal(t, len(concat), n)
 	assert.Equal(t, concat, readBuf[:n])
@@ -86,30 +88,30 @@ func TestWriteEnvironment(t *testing.T) {
 	var b bytes.Buffer
 
 	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	w, err := NewWriter(nil, enc, WithWEnvironment(&fakeWriteEnvironment{
 		bw: io.Writer(&b),
 	}))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	bytes1 := []byte("test")
 	_, err = w.Write(bytes1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	bytes2 := []byte("test2")
 	_, err = w.Write(bytes2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = w.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// test decompression
 	br := io.Reader(&b)
 	dec, err := zstd.NewReader(br)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	readBuf := make([]byte, 1024)
 	n, err := dec.Read(readBuf)
-	assert.Equal(t, err, io.EOF)
+	require.ErrorIs(t, err, io.EOF)
 	concat := append(bytes1, bytes2...)
 	assert.Equal(t, len(concat), n)
 	assert.Equal(t, concat, readBuf[:n])
@@ -117,17 +119,17 @@ func TestWriteEnvironment(t *testing.T) {
 
 func BenchmarkWrite(b *testing.B) {
 	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
-	assert.NoError(b, err)
+	require.NoError(b, err)
 
 	sizes := []int64{128, 4 * 1024, 16 * 1024, 64 * 1024, 1 * 1024 * 1024}
 	for _, sz := range sizes {
 		writeBuf := make([]byte, sz)
 		_, err := rand.Read(writeBuf)
-		assert.NoError(b, err)
+		require.NoError(b, err)
 		var buf bytes.Buffer
 		bw := io.Writer(&buf)
 		w, err := NewWriter(bw, enc)
-		assert.NoError(b, err)
+		require.NoError(b, err)
 
 		b.Run(fmt.Sprintf("%d", sz), func(b *testing.B) {
 			b.SetBytes(sz)
@@ -139,6 +141,6 @@ func BenchmarkWrite(b *testing.B) {
 			}
 		})
 		err = w.Close()
-		assert.NoError(b, err)
+		require.NoError(b, err)
 	}
 }


### PR DESCRIPTION
In this PR:
* Use `require` for error handling.
* Fix some actual/expected uses.
* Use `assert.Len`.
* Use `assert.ErrorIs`.
* Use `errors.Is`.
* Add a `FuzzRoundTrip` test data.

No non-test functional changes.