### PR TITLE
Make chan buffered for better performance

### DIFF
--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -161,7 +161,7 @@ func (s *writerImpl) writeManyProducer(ctx context.Context, frameSource FrameSou
 			// Put a channel on the queue as a sort of promise.
 			// This is a nice trick to keep our results ordered, even when compression
 			// completes out-of-order.
-			ch := make(chan encodeResult)
+			ch := make(chan encodeResult, 1)
 			select {
 			case <-ctx.Done():
 				return nil


### PR DESCRIPTION
Now all threads can hit 100%, otherwise encoders sit around waiting for something to read these. Forgot to fix this in my previous PR, sorry!