### PR TITLE
Fix comment typo in seekable.go

### DIFF
--- a/pkg/seekable.go
+++ b/pkg/seekable.go
@@ -58,7 +58,7 @@ const (
 )
 
 /*
-seekTableDescriptor is a Go representation of a bitfiled.
+seekTableDescriptor is a Go representation of a bitfield.
 
 A bitfield describing the format of the seek table.
 


### PR DESCRIPTION
## Summary
- correct `bitfiled` typo to `bitfield` in seekTableDescriptor comment

## Testing
- `go test ./pkg/...`
- `go test ./cmd/zstdseek/...`


------
https://chatgpt.com/codex/tasks/task_e_684c5eca5644833096b92655b8328466