### PR TITLE
Fix variable name typo

### DIFF
--- a/pkg/seekable_test.go
+++ b/pkg/seekable_test.go
@@ -50,9 +50,9 @@ func TestCreateSkippableFrame(t *testing.T) {
 			assert.Equal(t, tab.expectedErr, err, "createSkippableFrame err does not match expected")
 			if tab.expectedErr == nil && err == nil {
 				assert.Equal(t, tab.expectedBytes, actualBytes, "createSkippableFrame output does not match expected")
-				decodedeBytes, err := dec.DecodeAll(actualBytes, nil)
+				decodedBytes, err := dec.DecodeAll(actualBytes, nil)
 				require.NoError(t, err)
-				assert.Equal(t, []byte(nil), decodedeBytes)
+				assert.Equal(t, []byte(nil), decodedBytes)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- rename `decodedeBytes` to `decodedBytes` in `seekable_test.go`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c5ed9c5d88330916df14daf2e1080