### PR TITLE
Handle partial seek table writes

### DIFF
--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -233,6 +233,12 @@ func (s *writerImpl) writeSeekTable() error {
 		return err
 	}
 
-	_, err = s.env.WriteSeekTable(seekTableBytes)
-	return err
+	n, err := s.env.WriteSeekTable(seekTableBytes)
+	if err != nil {
+		return err
+	}
+	if n != len(seekTableBytes) {
+		return fmt.Errorf("partial write: %d out of %d", n, len(seekTableBytes))
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- check `WriteSeekTable` return value in `writeSeekTable`
- test close errors when the seek table write fails or is partial

## Testing
- `go vet ./...` in `pkg`
- `go vet ./...` in `cmd/zstdseek`
- `go test ./...` in `cmd/zstdseek`
- `go test ./...` in `pkg`


------
https://chatgpt.com/codex/tasks/task_e_684c5f1b95e08330bc1d9fe514fe1852