### PR TITLE
Handle nil ReadSeeker in NewReader

### DIFF
--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -161,6 +161,9 @@ func NewReader(rs io.ReadSeeker, decoder ZSTDDecoder, opts ...rOption) (Reader, 
 	}
 
 	if sr.env == nil {
+		if rs == nil {
+			return nil, fmt.Errorf("nil ReadSeeker and no custom environment supplied")
+		}
 		sr.env = &readSeekerEnvImpl{
 			rs: rs,
 		}

--- a/pkg/reader_test.go
+++ b/pkg/reader_test.go
@@ -580,3 +580,14 @@ func TestSeekTableParsing(t *testing.T) {
 	})
 	require.ErrorContains(t, err, "footer magic mismatch")
 }
+func TestNilReaderNoEnvironment(t *testing.T) {
+	t.Parallel()
+
+	dec, err := zstd.NewReader(nil)
+	require.NoError(t, err)
+	defer dec.Close()
+
+	r, err := NewReader(nil, dec)
+	require.Error(t, err)
+	assert.Nil(t, r)
+}


### PR DESCRIPTION
## Summary
- prevent nil dereference in `NewReader` when no environment is provided
- add regression test ensuring nil `ReadSeeker` returns an error

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c615391d083309effdd504488b08e