### PR TITLE
Fix log message variable in encoder

### DIFF
--- a/pkg/encoder.go
+++ b/pkg/encoder.go
@@ -41,7 +41,7 @@ func (s *writerImpl) encodeOne(src []byte) ([]byte, seekTableEntry, error) {
 	if int64(len(dst)) > maxChunkSize {
 		return nil, seekTableEntry{},
 			fmt.Errorf("result size too big for seekable format: %d > %d",
-				len(src), maxChunkSize)
+				len(dst), maxChunkSize)
 	}
 
 	return dst, seekTableEntry{


### PR DESCRIPTION
## Summary
- fix incorrect size variable used in encoder error message

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c62bd1eb08330b88af104de4617d3