### PR TITLE
Fix errcheck lints

### DIFF
--- a/pkg/example_test.go
+++ b/pkg/example_test.go
@@ -16,13 +16,17 @@ func Example() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer os.Remove(f.Name())
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
 
 	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer enc.Close()
+	defer func() {
+		_ = enc.Close()
+	}()
 
 	w, err := seekable.NewWriter(f, enc)
 	if err != nil {
@@ -53,7 +57,9 @@ func Example() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer r.Close()
+	defer func() {
+		_ = r.Close()
+	}()
 
 	ello := make([]byte, 4)
 	// ReaderAt

--- a/pkg/seekable.go
+++ b/pkg/seekable.go
@@ -136,7 +136,7 @@ func (f *seekTableFooter) UnmarshalBinary(p []byte) error {
 		return fmt.Errorf("footer length mismatch %d vs %d", len(p), seekTableFooterOffset)
 	}
 	// Check that reserved bits are set to 0.
-	var reservedBits uint8 = (p[4] << 1) >> 3
+	reservedBits := (p[4] << 1) >> 3
 	if reservedBits != 0 {
 		return fmt.Errorf("footer reserved bits %d != 0", reservedBits)
 	}

--- a/pkg/seekable_test.go
+++ b/pkg/seekable_test.go
@@ -78,7 +78,7 @@ func TestIntercompat(t *testing.T) {
 
 			f, err := os.Open(fmt.Sprintf("./testdata/%s", fn))
 			require.NoError(t, err)
-			defer f.Close()
+			defer func() { require.NoError(t, f.Close()) }()
 
 			r, err := NewReader(f, dec)
 			require.NoError(t, err)


### PR DESCRIPTION
## Summary
- handle deferred error checks
- infer reserved bits type

## Testing
- `go test ./pkg/...`
- `golangci-lint run ./...` in `pkg/`

------
https://chatgpt.com/codex/tasks/task_e_6850e3364d4c8330ba7ddc2f23ddffa9