### PR TITLE
Fix zero-length frame handling in writer

### DIFF
--- a/pkg/encoder.go
+++ b/pkg/encoder.go
@@ -53,8 +53,7 @@ func (s *writerImpl) encodeOne(src []byte) ([]byte, seekTableEntry, error) {
 
 func (s *writerImpl) Encode(src []byte) ([]byte, error) {
 	if len(src) == 0 {
-		// No-op writes should not produce frame entries or data.
-		return nil, nil
+		return []byte{}, nil
 	}
 
 	dst, entry, err := s.encodeOne(src)

--- a/pkg/encoder.go
+++ b/pkg/encoder.go
@@ -52,6 +52,11 @@ func (s *writerImpl) encodeOne(src []byte) ([]byte, seekTableEntry, error) {
 }
 
 func (s *writerImpl) Encode(src []byte) ([]byte, error) {
+	if len(src) == 0 {
+		// No-op writes should not produce frame entries or data.
+		return nil, nil
+	}
+
 	dst, entry, err := s.encodeOne(src)
 	if err != nil {
 		return nil, err

--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -157,6 +157,10 @@ func (s *writerImpl) writeManyProducer(ctx context.Context, frameSource FrameSou
 				close(queue)
 				return nil
 			}
+			if len(frame) == 0 {
+				// Skip empty frames entirely.
+				continue
+			}
 
 			// Put a channel on the queue as a sort of promise.
 			// This is a nice trick to keep our results ordered, even when compression

--- a/pkg/writer_test.go
+++ b/pkg/writer_test.go
@@ -252,6 +252,58 @@ func TestWriteEnvironment(t *testing.T) {
 	assert.Equal(t, concat, readBuf[:n])
 }
 
+func TestZeroSizedFrameIgnored(t *testing.T) {
+	t.Parallel()
+
+	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
+	require.NoError(t, err)
+
+	var b bytes.Buffer
+	w, err := NewWriter(&b, enc)
+	require.NoError(t, err)
+
+	var n int
+	// Write two real frames with an empty frame in between.
+	_, err = w.Write([]byte("foo"))
+	require.NoError(t, err)
+	n, err = w.Write([]byte{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "should not write anything for empty frame")
+	_, err = w.Write([]byte("bar"))
+	require.NoError(t, err)
+	_, err = w.Write([]byte{})
+	require.NoError(t, err)
+	_, err = w.Write([]byte{})
+	require.NoError(t, err)
+
+	require.NoError(t, w.Close())
+
+	dec, err := zstd.NewReader(nil)
+	require.NoError(t, err)
+	defer dec.Close()
+
+	r, err := NewReader(bytes.NewReader(b.Bytes()), dec)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, r.Close()) }()
+
+	rr := r.(*readerImpl)
+	assert.Equal(t, int64(len("foobar")), rr.Size())
+	assert.Equal(t, int64(2), rr.NumFrames())
+
+	idx := rr.GetIndexByID(1)
+	require.NotNil(t, idx)
+
+	expected := []byte("bar")
+	buf := make([]byte, len(expected))
+	n, err = r.ReadAt(buf, int64(idx.DecompOffset))
+	require.NoError(t, err)
+	assert.Equal(t, len(expected), n)
+	assert.Equal(t, expected, buf)
+
+	idx = rr.GetIndexByID(2)
+	require.Nil(t, idx)
+}
+
 func TestCloseErrors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- skip empty writes in `Encode`
- ignore zero-sized frames in concurrent writer producer
- add regression test ensuring empty frames are not indexed

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686bcd4dc4b483309c74e1ebaaa44c17