### PR TITLE
refactor: replace zap with pluggable Logger interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
   [![License][license-img]][license] [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Go Report][report-img]][report]
 # ZSTD seekable compression format implementation in Go
+
+> **Note**: This is a fork of [SaveTheRbtz/zstd-seekable-format-go](https://github.com/SaveTheRbtz/zstd-seekable-format-go) with a pluggable logging interface to remove the zap dependency.
+
 [Seekable ZSTD compression format](https://github.com/facebook/zstd/blob/dev/contrib/seekable_format/zstd_seekable_compression_format.md) implemented in Golang.
 
 This library provides a random access reader (using uncompressed file offsets) for ZSTD-compressed streams.  This can be used for creating transparent compression layers.  Coupled with Content Defined Chunking (CDC) it can also be used as a robust de-duplication layer.

--- a/pkg/decoder.go
+++ b/pkg/decoder.go
@@ -1,7 +1,7 @@
 package seekable
 
 import (
-	"github.com/SaveTheRbtz/zstd-seekable-format-go/pkg/env"
+	"github.com/rjasonadams/zstd-seekable-format-go/pkg/env"
 )
 
 // Decoder is a byte-oriented API that is useful for cases where wrapping io.ReadSeeker is not desirable.

--- a/pkg/encoder.go
+++ b/pkg/encoder.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/cespare/xxhash/v2"
-	"go.uber.org/zap"
 )
 
 // Encoder is a byte-oriented API that is useful where wrapping io.Writer is not desirable.
@@ -61,7 +60,7 @@ func (s *writerImpl) Encode(src []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	s.logger.Debug("appending frame", zap.Object("frame", &entry))
+	s.logger.Debug("appending frame", Any("frame", &entry))
 	s.frameEntries = append(s.frameEntries, entry)
 	return dst, nil
 }

--- a/pkg/env/frame_offset.go
+++ b/pkg/env/frame_offset.go
@@ -1,8 +1,6 @@
 package env
 
-import (
-	"go.uber.org/zap/zapcore"
-)
+import "fmt"
 
 // FrameOffsetEntry is the post-processed view of the Seek_Table_Entries suitable for indexing.
 type FrameOffsetEntry struct {
@@ -22,15 +20,9 @@ type FrameOffsetEntry struct {
 	Checksum uint32
 }
 
-func (o *FrameOffsetEntry) MarshalLogObject(enc zapcore.ObjectEncoder) error {
-	enc.AddInt64("ID", o.ID)
-	enc.AddUint64("CompOffset", o.CompOffset)
-	enc.AddUint64("DecompOffset", o.DecompOffset)
-	enc.AddUint32("CompSize", o.CompSize)
-	enc.AddUint32("DecompSize", o.DecompSize)
-	enc.AddUint32("Checksum", o.Checksum)
-
-	return nil
+func (o *FrameOffsetEntry) String() string {
+	return fmt.Sprintf("ID=%d CompOffset=%d DecompOffset=%d CompSize=%d DecompSize=%d Checksum=0x%X",
+		o.ID, o.CompOffset, o.DecompOffset, o.CompSize, o.DecompSize, o.Checksum)
 }
 
 func Less(a, b *FrameOffsetEntry) bool {

--- a/pkg/example_test.go
+++ b/pkg/example_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 
-	seekable "github.com/SaveTheRbtz/zstd-seekable-format-go/pkg"
+	seekable "github.com/rjasonadams/zstd-seekable-format-go/pkg"
 )
 
 func Example() {

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -8,13 +8,11 @@ require (
 	github.com/klauspost/compress v1.18.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/atomic v1.11.0
-	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.15.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,4 +1,4 @@
-module github.com/SaveTheRbtz/zstd-seekable-format-go/pkg
+module github.com/rjasonadams/zstd-seekable-format-go/pkg
 
 go 1.24.4
 

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -12,12 +12,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
-go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
-go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
-go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
-go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
-go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
 golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/pkg/logger.go
+++ b/pkg/logger.go
@@ -1,0 +1,41 @@
+package seekable
+
+// Logger is a minimal logging interface for the library.
+// Implementations can wrap any logging library (zap, logrus, slog, etc.).
+type Logger interface {
+	// Debug logs a debug-level message with structured fields.
+	Debug(msg string, fields ...Field)
+}
+
+// Field represents a structured logging field with a key-value pair.
+type Field struct {
+	Key   string
+	Value interface{}
+}
+
+// String creates a Field with a string value.
+func String(key, value string) Field {
+	return Field{Key: key, Value: value}
+}
+
+// Uint64 creates a Field with a uint64 value.
+func Uint64(key string, value uint64) Field {
+	return Field{Key: key, Value: value}
+}
+
+// Int creates a Field with an int value.
+func Int(key string, value int) Field {
+	return Field{Key: key, Value: value}
+}
+
+// Any creates a Field with any value type.
+func Any(key string, value interface{}) Field {
+	return Field{Key: key, Value: value}
+}
+
+// NoOpLogger is a logger implementation that discards all log messages.
+// This is the default logger used when none is provided.
+type NoOpLogger struct{}
+
+// Debug implements Logger.Debug by doing nothing.
+func (NoOpLogger) Debug(string, ...Field) {}

--- a/pkg/logger_example_test.go
+++ b/pkg/logger_example_test.go
@@ -1,0 +1,71 @@
+package seekable_test
+
+import (
+	"fmt"
+
+	seekable "github.com/SaveTheRbtz/zstd-seekable-format-go/pkg"
+)
+
+// ZapLogger demonstrates how to adapt zap.Logger to the seekable.Logger interface.
+// Uncomment this example if you want to use zap:
+//
+// import "go.uber.org/zap"
+//
+// type ZapLogger struct {
+//     *zap.Logger
+// }
+//
+// func (z ZapLogger) Debug(msg string, fields ...seekable.Field) {
+//     zapFields := make([]zap.Field, len(fields))
+//     for i, f := range fields {
+//         switch v := f.Value.(type) {
+//         case string:
+//             zapFields[i] = zap.String(f.Key, v)
+//         case int:
+//             zapFields[i] = zap.Int(f.Key, v)
+//         case uint64:
+//             zapFields[i] = zap.Uint64(f.Key, v)
+//         case uint32:
+//             zapFields[i] = zap.Uint32(f.Key, v)
+//         default:
+//             zapFields[i] = zap.Any(f.Key, v)
+//         }
+//     }
+//     z.Logger.Debug(msg, zapFields...)
+// }
+//
+// Usage:
+//     zapLogger, _ := zap.NewDevelopment()
+//     logger := ZapLogger{zapLogger}
+//     reader, err := seekable.NewReader(rs, decoder, seekable.WithRLogger(logger))
+
+// SimpleLogger demonstrates a basic logger implementation that prints to stdout.
+type SimpleLogger struct{}
+
+func (l SimpleLogger) Debug(msg string, fields ...seekable.Field) {
+	fmt.Print(msg)
+	for _, f := range fields {
+		fmt.Printf(" %s=%v", f.Key, f.Value)
+	}
+	fmt.Println()
+}
+
+// Example showing how to use a custom logger with the reader.
+func ExampleWithRLogger() {
+	// Create a simple logger
+	logger := SimpleLogger{}
+
+	// Use it when creating a reader
+	// reader, err := seekable.NewReader(rs, decoder, seekable.WithRLogger(logger))
+	_ = logger
+}
+
+// Example showing how to use a custom logger with the writer.
+func ExampleWithWLogger() {
+	// Create a simple logger
+	logger := SimpleLogger{}
+
+	// Use it when creating a writer
+	// writer, err := seekable.NewWriter(w, encoder, seekable.WithWLogger(logger))
+	_ = logger
+}

--- a/pkg/logger_example_test.go
+++ b/pkg/logger_example_test.go
@@ -3,7 +3,7 @@ package seekable_test
 import (
 	"fmt"
 
-	seekable "github.com/SaveTheRbtz/zstd-seekable-format-go/pkg"
+	seekable "github.com/rjasonadams/zstd-seekable-format-go/pkg"
 )
 
 // ZapLogger demonstrates how to adapt zap.Logger to the seekable.Logger interface.

--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/btree"
 	"go.uber.org/atomic"
 
-	"github.com/SaveTheRbtz/zstd-seekable-format-go/pkg/env"
+	"github.com/rjasonadams/zstd-seekable-format-go/pkg/env"
 )
 
 type cachedFrame struct {

--- a/pkg/reader_options.go
+++ b/pkg/reader_options.go
@@ -1,14 +1,13 @@
 package seekable
 
 import (
-	"go.uber.org/zap"
-
 	"github.com/SaveTheRbtz/zstd-seekable-format-go/pkg/env"
 )
 
 type rOption func(*readerImpl) error
 
-func WithRLogger(l *zap.Logger) rOption {
+// WithRLogger sets the logger for the reader.
+func WithRLogger(l Logger) rOption {
 	return func(r *readerImpl) error { r.logger = l; return nil }
 }
 

--- a/pkg/reader_options.go
+++ b/pkg/reader_options.go
@@ -1,7 +1,7 @@
 package seekable
 
 import (
-	"github.com/SaveTheRbtz/zstd-seekable-format-go/pkg/env"
+	"github.com/rjasonadams/zstd-seekable-format-go/pkg/env"
 )
 
 type rOption func(*readerImpl) error

--- a/pkg/reader_test.go
+++ b/pkg/reader_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/SaveTheRbtz/zstd-seekable-format-go/pkg/env"
+	"github.com/rjasonadams/zstd-seekable-format-go/pkg/env"
 )
 
 const sourceString = "testtest2"

--- a/pkg/seekable.go
+++ b/pkg/seekable.go
@@ -4,8 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-
-	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -83,9 +81,8 @@ type seekTableDescriptor struct {
 	ChecksumFlag bool
 }
 
-func (d *seekTableDescriptor) MarshalLogObject(enc zapcore.ObjectEncoder) error {
-	enc.AddBool("ChecksumFlag", d.ChecksumFlag)
-	return nil
+func (d *seekTableDescriptor) String() string {
+	return fmt.Sprintf("ChecksumFlag=%v", d.ChecksumFlag)
 }
 
 /*
@@ -122,13 +119,9 @@ func (f *seekTableFooter) MarshalBinary() ([]byte, error) {
 	return dst, nil
 }
 
-func (f *seekTableFooter) MarshalLogObject(enc zapcore.ObjectEncoder) error {
-	enc.AddUint32("NumberOfFrames", f.NumberOfFrames)
-	if err := enc.AddObject("SeekTableDescriptor", &f.SeekTableDescriptor); err != nil {
-		return err
-	}
-	enc.AddUint32("SeekableMagicNumber", f.SeekableMagicNumber)
-	return nil
+func (f *seekTableFooter) String() string {
+	return fmt.Sprintf("NumberOfFrames=%d ChecksumFlag=%v SeekableMagicNumber=0x%X",
+		f.NumberOfFrames, f.SeekTableDescriptor.ChecksumFlag, f.SeekableMagicNumber)
 }
 
 func (f *seekTableFooter) UnmarshalBinary(p []byte) error {
@@ -182,11 +175,9 @@ func (e *seekTableEntry) MarshalBinary() ([]byte, error) {
 	return dst, nil
 }
 
-func (e *seekTableEntry) MarshalLogObject(enc zapcore.ObjectEncoder) error {
-	enc.AddUint32("CompressedSize", e.CompressedSize)
-	enc.AddUint32("DecompressedSize", e.DecompressedSize)
-	enc.AddUint32("Checksum", e.Checksum)
-	return nil
+func (e *seekTableEntry) String() string {
+	return fmt.Sprintf("CompressedSize=%d DecompressedSize=%d Checksum=0x%X",
+		e.CompressedSize, e.DecompressedSize, e.Checksum)
 }
 
 func (e *seekTableEntry) UnmarshalBinary(p []byte) error {

--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"sync"
 
-	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/SaveTheRbtz/zstd-seekable-format-go/pkg/env"
@@ -33,7 +32,7 @@ type writerImpl struct {
 	enc          ZSTDEncoder
 	frameEntries []seekTableEntry
 
-	logger *zap.Logger
+	logger Logger
 	env    env.WEnvironment
 
 	mu sync.Mutex
@@ -82,7 +81,7 @@ func NewWriter(w io.Writer, encoder ZSTDEncoder, opts ...wOption) (ConcurrentWri
 		enc: encoder,
 	}
 
-	sw.logger = zap.NewNop()
+	sw.logger = NoOpLogger{}
 	for _, o := range opts {
 		err := o(&sw)
 		if err != nil {

--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -10,7 +10,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/SaveTheRbtz/zstd-seekable-format-go/pkg/env"
+	"github.com/rjasonadams/zstd-seekable-format-go/pkg/env"
 )
 
 var errWriterClosed = errors.New("writer is closed")

--- a/pkg/writer_options.go
+++ b/pkg/writer_options.go
@@ -3,14 +3,13 @@ package seekable
 import (
 	"fmt"
 
-	"go.uber.org/zap"
-
 	"github.com/SaveTheRbtz/zstd-seekable-format-go/pkg/env"
 )
 
 type wOption func(*writerImpl) error
 
-func WithWLogger(l *zap.Logger) wOption {
+// WithWLogger sets the logger for the writer.
+func WithWLogger(l Logger) wOption {
 	return func(w *writerImpl) error { w.logger = l; return nil }
 }
 

--- a/pkg/writer_options.go
+++ b/pkg/writer_options.go
@@ -3,7 +3,7 @@ package seekable
 import (
 	"fmt"
 
-	"github.com/SaveTheRbtz/zstd-seekable-format-go/pkg/env"
+	"github.com/rjasonadams/zstd-seekable-format-go/pkg/env"
 )
 
 type wOption func(*writerImpl) error


### PR DESCRIPTION
- Introduce minimal Logger interface with no external dependencies
- Add NoOpLogger as default implementation
- Replace *zap.Logger with Logger interface in reader and writer
- Remove all zapcore.ObjectEncoder dependencies
- Add String() methods to seekTableDescriptor, seekTableFooter, seekTableEntry, and FrameOffsetEntry for clean logging output
- Use WithRLogger/WithWLogger for consistency
- Include examples showing how to implement custom loggers (including zap adapter)
- Successfully remove go.uber.org/zap dependency from pkg module

This change allows users to integrate any logging library while keeping the package dependency-free for logging.