### PR TITLE
go: lower pkg version to 1.25.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,8 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.26.3']
-        dir: ['pkg', 'cmd/zstdseek']
+        include:
+          - go-version: '1.25.0'
+            dir: 'pkg'
+          - go-version: '1.26.3'
+            dir: 'pkg'
+          - go-version: '1.26.3'
+            dir: 'cmd/zstdseek'
     steps:
       - uses: dcarbone/install-jq-action@v3.2.0
       - uses: actions/checkout@v6

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,8 @@
 module github.com/SaveTheRbtz/zstd-seekable-format-go/pkg
 
-go 1.26.3
+go 1.25.0
+
+toolchain go1.26.3
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0


### PR DESCRIPTION
## Summary

Lower the library module's required Go version from `1.26.3` to `1.25.0` and keep `go1.26.3` as the preferred local toolchain via the `toolchain` directive.

Update `go.yml` so CI tests the library on both the minimum supported Go version (`1.25.0`) and the preferred toolchain version (`1.26.3`). The binary module remains on `1.26.3` in CI until its minimum is lowered separately.

## Why

The package source does not depend on Go 1.26.3 language or standard-library features. With the current dependency graph, the effective minimum is Go 1.25.0 because `golang.org/x/sync v0.20.0` declares `go 1.25.0`.

## Validation

- `env GOCACHE=/tmp/codex-go-build-cache go mod tidy` in `pkg`
- `env GOCACHE=/tmp/codex-go-build-cache go test ./...` in `pkg`
- `git diff --check`

Fixes https://github.com/SaveTheRbtz/zstd-seekable-format-go/issues/232