### PR TITLE
cmd/zstdseek: bump pkg to v0.9.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,13 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - go-version: '1.25.0'
-            dir: 'pkg'
-          - go-version: '1.26.3'
-            dir: 'pkg'
-          - go-version: '1.26.3'
-            dir: 'cmd/zstdseek'
+        go-version: ['1.25.0', '1.26.3']
+        dir: ['pkg', 'cmd/zstdseek']
+    env:
+      GOTOOLCHAIN: local
     steps:
       - uses: dcarbone/install-jq-action@v3.2.0
       - uses: actions/checkout@v6

--- a/cmd/zstdseek/go.mod
+++ b/cmd/zstdseek/go.mod
@@ -1,10 +1,12 @@
 module github.com/SaveTheRbtz/zstd-seekable-format-go/cmd/zstdseek
 
-go 1.26.3
+go 1.25.0
+
+toolchain go1.26.3
 
 require (
 	github.com/SaveTheRbtz/fastcdc-go v0.3.0
-	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.8.3
+	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.0
 	github.com/klauspost/compress v1.18.6
 	github.com/schollz/progressbar/v3 v3.19.0
 	go.uber.org/zap v1.28.0

--- a/cmd/zstdseek/go.sum
+++ b/cmd/zstdseek/go.sum
@@ -1,7 +1,7 @@
 github.com/SaveTheRbtz/fastcdc-go v0.3.0 h1:JdHvLlnijDuisYIwpRDcHZEjbxvCqtEmJ3gf35VJBgA=
 github.com/SaveTheRbtz/fastcdc-go v0.3.0/go.mod h1:2kMKqvBv1h9wCaUfETqsVkSESsCiFhp4YyEHyz7/SfE=
-github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.8.3 h1:ikrUPushSxbpr9mmDhSgz1KyUTChjwkDrxY/jzv2OTQ=
-github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.8.3/go.mod h1:bnXbvnI9Mfqdj4L3Y9aCsB1A/ztuYLNRzgVKsJFgR/U=
+github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.0 h1:Ll4yOKpGMvvA/TjNrDp4bDvi7nW8iRy8xFpNy1O23Ys=
+github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.0/go.mod h1:Lu5IBw6UTH8a4tmV8htv390pZikb21ZoNvcM0Y1aQho=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chengxilo/virtualterm v1.0.4 h1:Z6IpERbRVlfB8WkOmtbHiDbBANU7cimRIof7mk9/PwM=


### PR DESCRIPTION
## Summary

Bump `cmd/zstdseek` to consume `github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.0`.

Lower the binary module's required Go version from `1.26.3` to `1.25.0` and keep `go1.26.3` as the preferred toolchain via the `toolchain` directive.

Simplify `go.yml` back to a full matrix that tests both `pkg` and `cmd/zstdseek` with the minimum supported Go version (`1.25.0`) and preferred toolchain version (`1.26.3`). The workflow sets `GOTOOLCHAIN=local` so minimum-version jobs actually run the configured Go version.

## Validation

- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go mod tidy` in `cmd/zstdseek`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go test ./...` in `cmd/zstdseek`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go test ./...` in `pkg`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go build ./...` in `cmd/zstdseek`
- `git diff --check`