### PR TITLE
pkg: support zero-sized frames and improve perf

### DIFF
--- a/pkg/decoder.go
+++ b/pkg/decoder.go
@@ -1,6 +1,8 @@
 package seekable
 
 import (
+	"sort"
+
 	"github.com/SaveTheRbtz/zstd-seekable-format-go/pkg/env"
 )
 
@@ -70,24 +72,19 @@ func (r *readerImpl) GetIndexByDecompOffset(off uint64) (found *env.FrameOffsetE
 		return nil
 	}
 
-	r.index.DescendLessOrEqual(&env.FrameOffsetEntry{DecompOffset: off}, func(index *env.FrameOffsetEntry) bool {
-		found = index
-		return false
+	i := sort.Search(len(r.index), func(i int) bool {
+		return r.index[i].DecompOffset+uint64(r.index[i].DecompSize) > off
 	})
-	return
+	if i == len(r.index) || r.index[i].DecompOffset > off {
+		return nil
+	}
+	return &r.index[i]
 }
 
 func (r *readerImpl) GetIndexByID(id int64) (found *env.FrameOffsetEntry) {
-	if id < 0 {
+	if id < 0 || id >= int64(len(r.index)) {
 		return nil
 	}
 
-	r.index.Descend(func(index *env.FrameOffsetEntry) bool {
-		if index.ID == id {
-			found = index
-			return false
-		}
-		return true
-	})
-	return
+	return &r.index[int(id)]
 }

--- a/pkg/decoder_benchmark_test.go
+++ b/pkg/decoder_benchmark_test.go
@@ -1,0 +1,194 @@
+package seekable
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/SaveTheRbtz/zstd-seekable-format-go/pkg/env"
+)
+
+const benchmarkChunkIndexSize = 1 << 20
+
+var (
+	benchmarkLargeIndexOnce   sync.Once
+	benchmarkLargeIndexReader *readerImpl
+	benchmarkLargeIndexErr    error
+
+	benchmarkDecoderSink Decoder
+	benchmarkEntrySink   *env.FrameOffsetEntry
+	benchmarkIntSink     int64
+)
+
+func benchmarkLargeSeekTable(b testing.TB) []byte {
+	b.Helper()
+
+	const entrySize = 12
+	seekTable := make([]byte, benchmarkChunkIndexSize*entrySize+seekTableFooterOffset)
+	entry := seekTableEntry{CompressedSize: 1, DecompressedSize: 1}
+	for i := 0; i < benchmarkChunkIndexSize; i++ {
+		entry.marshalBinaryInline(seekTable[i*entrySize : (i+1)*entrySize])
+	}
+
+	footer := seekTableFooter{
+		NumberOfFrames: benchmarkChunkIndexSize,
+		SeekTableDescriptor: seekTableDescriptor{
+			ChecksumFlag: true,
+		},
+		SeekableMagicNumber: seekableMagicNumber,
+	}
+	footer.marshalBinaryInline(seekTable[benchmarkChunkIndexSize*entrySize:])
+
+	frame, err := createSkippableFrame(seekableTag, seekTable)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return frame
+}
+
+func benchmarkLargeReader(b *testing.B) *readerImpl {
+	b.Helper()
+
+	benchmarkLargeIndexOnce.Do(func() {
+		seekTable := benchmarkLargeSeekTable(b)
+		d, err := NewDecoder(seekTable, nil)
+		benchmarkLargeIndexErr = err
+		if err != nil {
+			return
+		}
+		benchmarkLargeIndexReader = d.(*readerImpl)
+	})
+	if benchmarkLargeIndexErr != nil {
+		b.Fatal(benchmarkLargeIndexErr)
+	}
+	return benchmarkLargeIndexReader
+}
+
+func BenchmarkDecoderLargeIndexBuild(b *testing.B) {
+	seekTable := benchmarkLargeSeekTable(b)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d, err := NewDecoder(seekTable, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchmarkDecoderSink = d
+		if err := d.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDecoderLargeIndexGetIndexByDecompOffset(b *testing.B) {
+	r := benchmarkLargeReader(b)
+
+	cases := []struct {
+		name string
+		off  uint64
+	}{
+		{name: "First", off: 0},
+		{name: "Middle", off: benchmarkChunkIndexSize / 2},
+		{name: "Last", off: benchmarkChunkIndexSize - 1},
+		{name: "MissPastEnd", off: benchmarkChunkIndexSize},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkEntrySink = r.GetIndexByDecompOffset(tc.off)
+			}
+		})
+	}
+
+	b.Run("Sequential", func(b *testing.B) {
+		var ids int64
+		mask := uint64(benchmarkChunkIndexSize - 1)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			index := r.GetIndexByDecompOffset(uint64(i) & mask)
+			if index != nil {
+				ids += index.ID
+			}
+		}
+		benchmarkIntSink = ids
+	})
+
+	b.Run("PseudoRandom", func(b *testing.B) {
+		var ids int64
+		x := uint64(1)
+		mask := uint64(benchmarkChunkIndexSize - 1)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			x = x*6364136223846793005 + 1
+			index := r.GetIndexByDecompOffset(x & mask)
+			if index != nil {
+				ids += index.ID
+			}
+		}
+		benchmarkIntSink = ids
+	})
+}
+
+func BenchmarkDecoderLargeIndexGetIndexByID(b *testing.B) {
+	r := benchmarkLargeReader(b)
+
+	cases := []struct {
+		name string
+		id   int64
+	}{
+		{name: "First", id: 0},
+		{name: "Middle", id: benchmarkChunkIndexSize / 2},
+		{name: "Last", id: benchmarkChunkIndexSize - 1},
+		{name: "MissNegative", id: -1},
+		{name: "MissPastEnd", id: benchmarkChunkIndexSize},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkEntrySink = r.GetIndexByID(tc.id)
+			}
+		})
+	}
+
+	b.Run("Sequential", func(b *testing.B) {
+		var ids int64
+		mask := int64(benchmarkChunkIndexSize - 1)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			index := r.GetIndexByID(int64(i) & mask)
+			if index != nil {
+				ids += index.ID
+			}
+		}
+		benchmarkIntSink = ids
+	})
+
+	b.Run("PseudoRandom", func(b *testing.B) {
+		var ids int64
+		x := uint64(1)
+		mask := uint64(benchmarkChunkIndexSize - 1)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			x = x*6364136223846793005 + 1
+			index := r.GetIndexByID(int64(x & mask))
+			if index != nil {
+				ids += index.ID
+			}
+		}
+		benchmarkIntSink = ids
+	})
+}

--- a/pkg/decoder_benchmark_test.go
+++ b/pkg/decoder_benchmark_test.go
@@ -1,42 +1,44 @@
 package seekable
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/SaveTheRbtz/zstd-seekable-format-go/pkg/env"
 )
 
-const benchmarkChunkIndexSize = 1 << 20
+var benchmarkChunkIndexSizes = []struct {
+	name string
+	size int
+}{
+	{name: "16K", size: 16 << 10},
+	{name: "128K", size: 128 << 10},
+	{name: "1M", size: 1 << 20},
+}
 
 var (
-	benchmarkLargeIndexOnce   sync.Once
-	benchmarkLargeIndexReader *readerImpl
-	benchmarkLargeIndexErr    error
-
 	benchmarkDecoderSink Decoder
 	benchmarkEntrySink   *env.FrameOffsetEntry
 	benchmarkIntSink     int64
 )
 
-func benchmarkLargeSeekTable(b testing.TB) []byte {
+func benchmarkSeekTable(b testing.TB, size int) []byte {
 	b.Helper()
 
 	const entrySize = 12
-	seekTable := make([]byte, benchmarkChunkIndexSize*entrySize+seekTableFooterOffset)
+	seekTable := make([]byte, size*entrySize+seekTableFooterOffset)
 	entry := seekTableEntry{CompressedSize: 1, DecompressedSize: 1}
-	for i := 0; i < benchmarkChunkIndexSize; i++ {
+	for i := 0; i < size; i++ {
 		entry.marshalBinaryInline(seekTable[i*entrySize : (i+1)*entrySize])
 	}
 
 	footer := seekTableFooter{
-		NumberOfFrames: benchmarkChunkIndexSize,
+		NumberOfFrames: uint32(size),
 		SeekTableDescriptor: seekTableDescriptor{
 			ChecksumFlag: true,
 		},
 		SeekableMagicNumber: seekableMagicNumber,
 	}
-	footer.marshalBinaryInline(seekTable[benchmarkChunkIndexSize*entrySize:])
+	footer.marshalBinaryInline(seekTable[size*entrySize:])
 
 	frame, err := createSkippableFrame(seekableTag, seekTable)
 	if err != nil {
@@ -45,150 +47,165 @@ func benchmarkLargeSeekTable(b testing.TB) []byte {
 	return frame
 }
 
-func benchmarkLargeReader(b *testing.B) *readerImpl {
+func benchmarkReader(b *testing.B, size int) *readerImpl {
 	b.Helper()
 
-	benchmarkLargeIndexOnce.Do(func() {
-		seekTable := benchmarkLargeSeekTable(b)
-		d, err := NewDecoder(seekTable, nil)
-		benchmarkLargeIndexErr = err
-		if err != nil {
-			return
-		}
-		benchmarkLargeIndexReader = d.(*readerImpl)
-	})
-	if benchmarkLargeIndexErr != nil {
-		b.Fatal(benchmarkLargeIndexErr)
+	seekTable := benchmarkSeekTable(b, size)
+	d, err := NewDecoder(seekTable, nil)
+	if err != nil {
+		b.Fatal(err)
 	}
-	return benchmarkLargeIndexReader
+	return d.(*readerImpl)
 }
 
-func BenchmarkDecoderLargeIndexBuild(b *testing.B) {
-	seekTable := benchmarkLargeSeekTable(b)
+func BenchmarkDecoderIndexBuild(b *testing.B) {
+	for _, benchmarkSize := range benchmarkChunkIndexSizes {
+		b.Run(benchmarkSize.name, func(b *testing.B) {
+			seekTable := benchmarkSeekTable(b, benchmarkSize.size)
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		d, err := NewDecoder(seekTable, nil)
-		if err != nil {
-			b.Fatal(err)
-		}
-		benchmarkDecoderSink = d
-		if err := d.Close(); err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func BenchmarkDecoderLargeIndexGetIndexByDecompOffset(b *testing.B) {
-	r := benchmarkLargeReader(b)
-
-	cases := []struct {
-		name string
-		off  uint64
-	}{
-		{name: "First", off: 0},
-		{name: "Middle", off: benchmarkChunkIndexSize / 2},
-		{name: "Last", off: benchmarkChunkIndexSize - 1},
-		{name: "MissPastEnd", off: benchmarkChunkIndexSize},
-	}
-
-	for _, tc := range cases {
-		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				benchmarkEntrySink = r.GetIndexByDecompOffset(tc.off)
+				d, err := NewDecoder(seekTable, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkDecoderSink = d
+				if err := d.Close(); err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}
-
-	b.Run("Sequential", func(b *testing.B) {
-		var ids int64
-		mask := uint64(benchmarkChunkIndexSize - 1)
-
-		b.ReportAllocs()
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			index := r.GetIndexByDecompOffset(uint64(i) & mask)
-			if index != nil {
-				ids += index.ID
-			}
-		}
-		benchmarkIntSink = ids
-	})
-
-	b.Run("PseudoRandom", func(b *testing.B) {
-		var ids int64
-		x := uint64(1)
-		mask := uint64(benchmarkChunkIndexSize - 1)
-
-		b.ReportAllocs()
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			x = x*6364136223846793005 + 1
-			index := r.GetIndexByDecompOffset(x & mask)
-			if index != nil {
-				ids += index.ID
-			}
-		}
-		benchmarkIntSink = ids
-	})
 }
 
-func BenchmarkDecoderLargeIndexGetIndexByID(b *testing.B) {
-	r := benchmarkLargeReader(b)
+func BenchmarkDecoderGetIndexByDecompOffset(b *testing.B) {
+	for _, benchmarkSize := range benchmarkChunkIndexSizes {
+		b.Run(benchmarkSize.name, func(b *testing.B) {
+			r := benchmarkReader(b, benchmarkSize.size)
+			defer func() {
+				if err := r.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}()
 
-	cases := []struct {
-		name string
-		id   int64
-	}{
-		{name: "First", id: 0},
-		{name: "Middle", id: benchmarkChunkIndexSize / 2},
-		{name: "Last", id: benchmarkChunkIndexSize - 1},
-		{name: "MissNegative", id: -1},
-		{name: "MissPastEnd", id: benchmarkChunkIndexSize},
-	}
-
-	for _, tc := range cases {
-		b.Run(tc.name, func(b *testing.B) {
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				benchmarkEntrySink = r.GetIndexByID(tc.id)
+			cases := []struct {
+				name string
+				off  uint64
+			}{
+				{name: "First", off: 0},
+				{name: "Middle", off: uint64(benchmarkSize.size / 2)},
+				{name: "Last", off: uint64(benchmarkSize.size - 1)},
+				{name: "MissPastEnd", off: uint64(benchmarkSize.size)},
 			}
+
+			for _, tc := range cases {
+				b.Run(tc.name, func(b *testing.B) {
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						benchmarkEntrySink = r.GetIndexByDecompOffset(tc.off)
+					}
+				})
+			}
+
+			b.Run("Sequential", func(b *testing.B) {
+				var ids int64
+				mask := uint64(benchmarkSize.size - 1)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					index := r.GetIndexByDecompOffset(uint64(i) & mask)
+					if index != nil {
+						ids += index.ID
+					}
+				}
+				benchmarkIntSink = ids
+			})
+
+			b.Run("PseudoRandom", func(b *testing.B) {
+				var ids int64
+				x := uint64(1)
+				mask := uint64(benchmarkSize.size - 1)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					x = x*6364136223846793005 + 1
+					index := r.GetIndexByDecompOffset(x & mask)
+					if index != nil {
+						ids += index.ID
+					}
+				}
+				benchmarkIntSink = ids
+			})
 		})
 	}
+}
 
-	b.Run("Sequential", func(b *testing.B) {
-		var ids int64
-		mask := int64(benchmarkChunkIndexSize - 1)
+func BenchmarkDecoderGetIndexByID(b *testing.B) {
+	for _, benchmarkSize := range benchmarkChunkIndexSizes {
+		b.Run(benchmarkSize.name, func(b *testing.B) {
+			r := benchmarkReader(b, benchmarkSize.size)
+			defer func() {
+				if err := r.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}()
 
-		b.ReportAllocs()
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			index := r.GetIndexByID(int64(i) & mask)
-			if index != nil {
-				ids += index.ID
+			cases := []struct {
+				name string
+				id   int64
+			}{
+				{name: "First", id: 0},
+				{name: "Middle", id: int64(benchmarkSize.size / 2)},
+				{name: "Last", id: int64(benchmarkSize.size - 1)},
+				{name: "MissNegative", id: -1},
+				{name: "MissPastEnd", id: int64(benchmarkSize.size)},
 			}
-		}
-		benchmarkIntSink = ids
-	})
 
-	b.Run("PseudoRandom", func(b *testing.B) {
-		var ids int64
-		x := uint64(1)
-		mask := uint64(benchmarkChunkIndexSize - 1)
-
-		b.ReportAllocs()
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			x = x*6364136223846793005 + 1
-			index := r.GetIndexByID(int64(x & mask))
-			if index != nil {
-				ids += index.ID
+			for _, tc := range cases {
+				b.Run(tc.name, func(b *testing.B) {
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						benchmarkEntrySink = r.GetIndexByID(tc.id)
+					}
+				})
 			}
-		}
-		benchmarkIntSink = ids
-	})
+
+			b.Run("Sequential", func(b *testing.B) {
+				var ids int64
+				mask := int64(benchmarkSize.size - 1)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					index := r.GetIndexByID(int64(i) & mask)
+					if index != nil {
+						ids += index.ID
+					}
+				}
+				benchmarkIntSink = ids
+			})
+
+			b.Run("PseudoRandom", func(b *testing.B) {
+				var ids int64
+				x := uint64(1)
+				mask := uint64(benchmarkSize.size - 1)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					x = x*6364136223846793005 + 1
+					index := r.GetIndexByID(int64(x & mask))
+					if index != nil {
+						ids += index.ID
+					}
+				}
+				benchmarkIntSink = ids
+			})
+		})
+	}
 }

--- a/pkg/decoder_test.go
+++ b/pkg/decoder_test.go
@@ -84,6 +84,70 @@ func TestDecoderRejectsSeekTableEntryCountMismatch(t *testing.T) {
 	assert.Nil(t, d)
 }
 
+func TestDecoderZeroSizeEntries(t *testing.T) {
+	t.Parallel()
+
+	entries := []seekTableEntry{
+		{CompressedSize: 2, DecompressedSize: 0},
+		{CompressedSize: 10, DecompressedSize: 3},
+		{CompressedSize: 5, DecompressedSize: 0},
+		{CompressedSize: 20, DecompressedSize: 4},
+		{CompressedSize: 7, DecompressedSize: 0},
+	}
+	seekTable := mustCreateSeekTableFrame(t, entries, uint32(len(entries)))
+
+	d, err := NewDecoder(seekTable, nil)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, d.Close()) }()
+
+	assert.Equal(t, int64(7), d.Size())
+	assert.Equal(t, int64(5), d.NumFrames())
+
+	indexID0 := d.GetIndexByID(0)
+	require.NotNil(t, indexID0)
+	assert.Equal(t, int64(0), indexID0.ID)
+	assert.Equal(t, uint64(0), indexID0.DecompOffset)
+	assert.Equal(t, uint32(0), indexID0.DecompSize)
+
+	indexID2 := d.GetIndexByID(2)
+	require.NotNil(t, indexID2)
+	assert.Equal(t, int64(2), indexID2.ID)
+	assert.Equal(t, uint64(3), indexID2.DecompOffset)
+	assert.Equal(t, uint32(0), indexID2.DecompSize)
+
+	indexID4 := d.GetIndexByID(4)
+	require.NotNil(t, indexID4)
+	assert.Equal(t, int64(4), indexID4.ID)
+	assert.Equal(t, uint64(7), indexID4.DecompOffset)
+	assert.Equal(t, uint32(0), indexID4.DecompSize)
+
+	indexID1 := d.GetIndexByID(1)
+	require.NotNil(t, indexID1)
+	assert.Equal(t, int64(1), indexID1.ID)
+	assert.Equal(t, uint64(0), indexID1.DecompOffset)
+	assert.Equal(t, uint32(3), indexID1.DecompSize)
+
+	indexID3 := d.GetIndexByID(3)
+	require.NotNil(t, indexID3)
+	assert.Equal(t, int64(3), indexID3.ID)
+	assert.Equal(t, uint64(3), indexID3.DecompOffset)
+	assert.Equal(t, uint32(4), indexID3.DecompSize)
+
+	for _, off := range []uint64{0, 1, 2} {
+		index := d.GetIndexByDecompOffset(off)
+		require.NotNil(t, index)
+		assert.Equal(t, int64(1), index.ID)
+	}
+
+	for _, off := range []uint64{3, 4, 6} {
+		index := d.GetIndexByDecompOffset(off)
+		require.NotNil(t, index)
+		assert.Equal(t, int64(3), index.ID)
+	}
+
+	assert.Nil(t, d.GetIndexByDecompOffset(7))
+}
+
 func mustCreateSeekTableFrame(t testing.TB, entries []seekTableEntry, numberOfFrames uint32) []byte {
 	t.Helper()
 

--- a/pkg/env/frame_offset.go
+++ b/pkg/env/frame_offset.go
@@ -35,7 +35,3 @@ func (o *FrameOffsetEntry) LogValue() slog.Value {
 		slog.Uint64("Checksum", uint64(o.Checksum)),
 	)
 }
-
-func Less(a, b *FrameOffsetEntry) bool {
-	return a.DecompOffset < b.DecompOffset
-}

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -6,7 +6,6 @@ toolchain go1.26.3
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0
-	github.com/google/btree v1.1.3
 	github.com/klauspost/compress v1.18.6
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.20.0

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -2,8 +2,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
-github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -11,7 +11,6 @@ import (
 	"sync/atomic"
 
 	"github.com/cespare/xxhash/v2"
-	"github.com/google/btree"
 
 	"github.com/SaveTheRbtz/zstd-seekable-format-go/pkg/env"
 )
@@ -99,7 +98,7 @@ func (rs *readSeekerEnvImpl) ReadSkipFrame(skippableFrameOffset int64) ([]byte, 
 
 type readerImpl struct {
 	dec   ZSTDDecoder
-	index *btree.BTreeG[*env.FrameOffsetEntry]
+	index []env.FrameOffsetEntry
 
 	checksums bool
 
@@ -173,12 +172,12 @@ func NewReader(rs io.ReadSeeker, decoder ZSTDDecoder, opts ...rOption) (Reader, 
 		}
 	}
 
-	tree, last, err := sr.indexFooter()
+	index, last, err := sr.indexFooter()
 	if err != nil {
 		return nil, err
 	}
 
-	sr.index = tree
+	sr.index = index
 	if last != nil {
 		sr.endOffset = int64(last.DecompOffset) + int64(last.DecompSize)
 		sr.numFrames = last.ID + 1
@@ -316,7 +315,7 @@ func (r *readerImpl) Seek(offset int64, whence int) (int64, error) {
 	return r.offset, nil
 }
 
-func (r *readerImpl) indexFooter() (*btree.BTreeG[*env.FrameOffsetEntry], *env.FrameOffsetEntry, error) {
+func (r *readerImpl) indexFooter() ([]env.FrameOffsetEntry, *env.FrameOffsetEntry, error) {
 	// read seekTableFooter
 	buf, err := r.env.ReadFooter()
 	if err != nil {
@@ -386,8 +385,11 @@ func (r *readerImpl) indexFooter() (*btree.BTreeG[*env.FrameOffsetEntry], *env.F
 }
 
 func (r *readerImpl) indexSeekTableEntries(p []byte, entrySize uint64, numberOfFrames uint32) (
-	*btree.BTreeG[*env.FrameOffsetEntry], *env.FrameOffsetEntry, error,
+	[]env.FrameOffsetEntry, *env.FrameOffsetEntry, error,
 ) {
+	if entrySize == 0 {
+		return nil, nil, fmt.Errorf("seek table entry size is 0")
+	}
 	if uint64(len(p))%entrySize != 0 {
 		return nil, nil, fmt.Errorf("seek table size is not multiple of %d", entrySize)
 	}
@@ -397,12 +399,10 @@ func (r *readerImpl) indexSeekTableEntries(p []byte, entrySize uint64, numberOfF
 			parsedEntries, numberOfFrames)
 	}
 
-	// TODO: make fan-out tunable?
-	t := btree.NewG(8, env.Less)
+	index := make([]env.FrameOffsetEntry, 0, int(uint64(len(p))/entrySize))
 	entry := seekTableEntry{}
 	var compOffset, decompOffset uint64
 
-	var last *env.FrameOffsetEntry
 	var i int64
 	for indexOffset := uint64(0); indexOffset < uint64(len(p)); indexOffset += entrySize {
 		err := entry.UnmarshalBinary(p[indexOffset : indexOffset+entrySize])
@@ -411,19 +411,22 @@ func (r *readerImpl) indexSeekTableEntries(p []byte, entrySize uint64, numberOfF
 				p[indexOffset:indexOffset+entrySize], indexOffset, err)
 		}
 
-		last = &env.FrameOffsetEntry{
+		index = append(index, env.FrameOffsetEntry{
 			ID:           i,
 			CompOffset:   compOffset,
 			DecompOffset: decompOffset,
 			CompSize:     entry.CompressedSize,
 			DecompSize:   entry.DecompressedSize,
 			Checksum:     entry.Checksum,
-		}
-		t.ReplaceOrInsert(last)
+		})
 		compOffset += uint64(entry.CompressedSize)
 		decompOffset += uint64(entry.DecompressedSize)
 		i++
 	}
 
-	return t, last, nil
+	if len(index) == 0 {
+		return index, nil, nil
+	}
+
+	return index, &index[len(index)-1], nil
 }

--- a/pkg/reader_test.go
+++ b/pkg/reader_test.go
@@ -150,7 +150,7 @@ func TestReader(t *testing.T) {
 
 		sr := r.(*readerImpl)
 		assert.Equal(t, int64(9), sr.endOffset)
-		assert.Equal(t, 2, sr.index.Len())
+		assert.Len(t, sr.index, 2)
 		assert.Equal(t, int64(0), sr.offset)
 
 		bytes1 := []byte("test")


### PR DESCRIPTION
This PR adds support for zero-sized frames.  It also shrinks deps and improves the perf.

Also removed unused `env.Less`.  If you depended on the removed `env.Less` helper, replace it with a local comparator:

```golang
func frameOffsetEntryLess(a, b *env.FrameOffsetEntry) bool {
      if a.DecompOffset != b.DecompOffset {
              return a.DecompOffset < b.DecompOffset
      }
      return a.ID < b.ID
}
```

## Build Time

| Size | Old B-tree | New slice | Speedup |
|---:|---:|---:|---:|
| 128K | 24.7 ms, 11.5 MB, 191,948 allocs | 1.51 ms, 5.24 MB, 2 allocs | 16.4x |
| 1M | 211 ms, 92.3 MB, 1,535,424 allocs | 10.1 ms, 41.9 MB, 2 allocs | 20.9x |
| 16M | 3.98 s, 1.48 GB, 24,566,648 allocs | 183 ms, 671 MB, 2 allocs | 21.8x |
| 128M | 32.5 s, 11.8 GB, 196,533,112 allocs | 1.31 s, 5.37 GB, 2 allocs | 24.8x |

## Offset Lookup

Each op is a batch of 65,536 lookups.

| Size | Random old | Random new | Sequential old | Sequential new |
|---:|---:|---:|---:|---:|
| 128K | 43.2 ms | 17.6 ms | 36.0 ms | 5.09 ms |
| 1M | 73.7 ms | 35.3 ms | 20.1 ms | 5.67 ms |
| 16M | 117 ms | 64.3 ms | 17.0 ms | 5.97 ms |
| 128M | 150 ms | 85.5 ms | 20.3 ms | 8.18 ms |

Old B-tree offset lookup also allocated 65,536 times per batch, about 3.15 MB total, because the old implementation creates a temporary key per lookup. The slice implementation was 0 allocs.

## ID Lookup

Single lookup per benchmark op, so sub-microsecond new-slice numbers are mostly timer overhead, but the scaling difference is clear.

| Size | Old first | New first | Old middle | New middle | Old miss | New miss |
|---:|---:|---:|---:|---:|---:|---:|
| 128K | 1.34 ms | 352 ns | 774 us | 405 ns | 1.39 ms | 333 ns |
| 1M | 12.6 ms | 382 ns | 8.09 ms | 304 ns | 15.6 ms | 324 ns |
| 16M | 263 ms | 325 ns | 170 ms | 315 ns | 280 ms | 398 ns |
| 128M | 1.40 s | 345 ns | 634 ms | 773 ns | 1.44 s | 441 ns |

Old `GetIndexByID(last)` is the one favorable B-tree scan case because the old code descends from the end; at 128M it was ~14.4 us versus ~502 ns for the slice.

Benchstat highlights:

  - Build: 16K 288.7µs, 128K 2.177ms, 1M 16.62ms.
  - Build allocs: 640.3KiB, 5.000MiB, 40.00MiB, all 6 allocs/op.
  - Offset lookup random: 16K 106.8ns, 128K 192.4ns, 1M 570.3ns.
  - ID lookup random: 16K 2.192ns, 128K 3.315ns, 1M 11.79ns.
  - All lookup benchmarks were 0 B/op, 0 allocs/op.