### PR TITLE
pkg: validate seek table entry count

### DIFF
--- a/pkg/decoder_test.go
+++ b/pkg/decoder_test.go
@@ -70,3 +70,39 @@ func TestDecoder(t *testing.T) {
 		assert.Nil(t, d.GetIndexByID(id))
 	}
 }
+
+func TestDecoderRejectsSeekTableEntryCountMismatch(t *testing.T) {
+	t.Parallel()
+
+	seekTable := mustCreateSeekTableFrame(t, []seekTableEntry{
+		{CompressedSize: 1, DecompressedSize: 1},
+		{CompressedSize: 1, DecompressedSize: 1},
+	}, 1)
+
+	d, err := NewDecoder(seekTable, nil)
+	require.ErrorContains(t, err, "seek table entry count mismatch")
+	assert.Nil(t, d)
+}
+
+func mustCreateSeekTableFrame(t testing.TB, entries []seekTableEntry, numberOfFrames uint32) []byte {
+	t.Helper()
+
+	const entrySize = 12
+	seekTable := make([]byte, len(entries)*entrySize+seekTableFooterOffset)
+	for i, entry := range entries {
+		entry.marshalBinaryInline(seekTable[i*entrySize : (i+1)*entrySize])
+	}
+
+	footer := seekTableFooter{
+		NumberOfFrames: numberOfFrames,
+		SeekTableDescriptor: seekTableDescriptor{
+			ChecksumFlag: true,
+		},
+		SeekableMagicNumber: seekableMagicNumber,
+	}
+	footer.marshalBinaryInline(seekTable[len(entries)*entrySize:])
+
+	frame, err := createSkippableFrame(seekableTag, seekTable)
+	require.NoError(t, err)
+	return frame
+}

--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -378,14 +378,23 @@ func (r *readerImpl) indexFooter() (*btree.BTreeG[*env.FrameOffsetEntry], *env.F
 		return nil, nil, fmt.Errorf("frame is too big: %d > %d", frameSize, maxDecoderFrameSize)
 	}
 
-	return r.indexSeekTableEntries(buf[8:len(buf)-seekTableFooterOffset], uint64(seekTableEntrySize))
+	return r.indexSeekTableEntries(
+		buf[8:len(buf)-seekTableFooterOffset],
+		uint64(seekTableEntrySize),
+		footer.NumberOfFrames,
+	)
 }
 
-func (r *readerImpl) indexSeekTableEntries(p []byte, entrySize uint64) (
+func (r *readerImpl) indexSeekTableEntries(p []byte, entrySize uint64, numberOfFrames uint32) (
 	*btree.BTreeG[*env.FrameOffsetEntry], *env.FrameOffsetEntry, error,
 ) {
 	if uint64(len(p))%entrySize != 0 {
 		return nil, nil, fmt.Errorf("seek table size is not multiple of %d", entrySize)
+	}
+	parsedEntries := uint64(len(p)) / entrySize
+	if parsedEntries != uint64(numberOfFrames) {
+		return nil, nil, fmt.Errorf("seek table entry count mismatch: parsed %d, footer %d",
+			parsedEntries, numberOfFrames)
 	}
 
 	// TODO: make fan-out tunable?


### PR DESCRIPTION
## Summary

- Validate that the number of parsed seek-table entries matches the footer's `NumberOfFrames` value.
- Reject malformed seek tables where the payload contains extra or missing entries for the advertised frame count.
- Add decoder regression coverage for mismatched entry counts.


## Validation

- `go test ./...` in `pkg`
- `go test -race ./...` in `pkg`
- `go test ./...` in `cmd/zstdseek`