### PR TITLE
pkg: handle short ReaderAt reads

### DIFF
--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -44,28 +44,33 @@ type readSeekerEnvImpl struct {
 	mu sync.Mutex
 }
 
-func (rs *readSeekerEnvImpl) GetFrameByIndex(index env.FrameOffsetEntry) (p []byte, err error) {
-	p = make([]byte, index.CompSize)
+func (rs *readSeekerEnvImpl) GetFrameByIndex(index env.FrameOffsetEntry) ([]byte, error) {
+	p := make([]byte, index.CompSize)
 	off := int64(index.CompOffset)
 
 	switch v := rs.rs.(type) {
 	case io.ReaderAt:
-		_, err = v.ReadAt(p, off)
-		if errors.Is(err, io.EOF) {
-			err = nil
+		n, err := v.ReadAt(p, off)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return nil, err
+		}
+		if n != len(p) {
+			return nil, io.ErrUnexpectedEOF
 		}
 	default:
 		rs.mu.Lock()
 		defer rs.mu.Unlock()
 
-		_, err = v.Seek(off, io.SeekStart)
+		_, err := v.Seek(off, io.SeekStart)
 		if err != nil {
 			return nil, err
 		}
-		_, err = io.ReadFull(rs.rs, p)
+		if _, err := io.ReadFull(rs.rs, p); err != nil {
+			return nil, err
+		}
 	}
 
-	return
+	return p, nil
 }
 
 func (rs *readSeekerEnvImpl) ReadFooter() ([]byte, error) {

--- a/pkg/reader_test.go
+++ b/pkg/reader_test.go
@@ -194,6 +194,37 @@ func TestReader(t *testing.T) {
 	}
 }
 
+func TestGetFrameByIndexShortReaderAt(t *testing.T) {
+	t.Parallel()
+
+	r := &readSeekerEnvImpl{rs: bytes.NewReader([]byte{0})}
+
+	_, err := r.GetFrameByIndex(env.FrameOffsetEntry{CompSize: 2})
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+type shortErrorReaderAt struct {
+	*bytes.Reader
+	err error
+}
+
+func (r *shortErrorReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	return 1, r.err
+}
+
+func TestGetFrameByIndexPreservesReaderAtError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("read failed")
+	r := &readSeekerEnvImpl{rs: &shortErrorReaderAt{
+		Reader: bytes.NewReader([]byte{0}),
+		err:    expectedErr,
+	}}
+
+	_, err := r.GetFrameByIndex(env.FrameOffsetEntry{CompSize: 2})
+	require.ErrorIs(t, err, expectedErr)
+}
+
 func TestReaderEdges(t *testing.T) {
 	dec, err := zstd.NewReader(nil)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Require `io.ReaderAt` frame reads to fill the requested compressed frame buffer.
- Return `io.ErrUnexpectedEOF` when `ReadAt` returns a short read instead of suppressing `io.EOF`.
- Add regression coverage for a short compressed-frame read through the seekable reader.

## Validation

- `go test ./...` in `pkg`
- `go test -race ./...` in `pkg`
- `go test ./...` in `cmd/zstdseek`