### PR TITLE
writer: return WriteMany cancellation errors

### DIFF
--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -190,7 +190,7 @@ func (s *writerImpl) writeManyEncoder(ctx context.Context, ch chan<- encodeResul
 
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return context.Cause(ctx)
 		case ch <- encodeResult{dst, entry}:
 			close(ch)
 		}
@@ -221,7 +221,7 @@ func (s *writerImpl) writeManyProducer(ctx context.Context, frameSource FrameSou
 			ch := make(chan encodeResult, 1)
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return context.Cause(ctx)
 			case queue <- ch:
 			}
 
@@ -236,7 +236,7 @@ func (s *writerImpl) writeManyConsumer(ctx context.Context, callback func(uint32
 			var ch <-chan encodeResult
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return context.Cause(ctx)
 			case ch = <-queue:
 			}
 			if ch == nil {
@@ -247,7 +247,7 @@ func (s *writerImpl) writeManyConsumer(ctx context.Context, callback func(uint32
 			var result encodeResult
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return context.Cause(ctx)
 			case result = <-ch:
 			}
 
@@ -279,7 +279,7 @@ func (s *writerImpl) WriteMany(ctx context.Context, frameSource FrameSource, opt
 	if s.failed {
 		return errWriterFailed
 	}
-	if err := ctx.Err(); err != nil {
+	if err := context.Cause(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -190,7 +190,7 @@ func (s *writerImpl) writeManyEncoder(ctx context.Context, ch chan<- encodeResul
 
 		select {
 		case <-ctx.Done():
-		// Fulfill our promise
+			return ctx.Err()
 		case ch <- encodeResult{dst, entry}:
 			close(ch)
 		}
@@ -221,7 +221,7 @@ func (s *writerImpl) writeManyProducer(ctx context.Context, frameSource FrameSou
 			ch := make(chan encodeResult, 1)
 			select {
 			case <-ctx.Done():
-				return nil
+				return ctx.Err()
 			case queue <- ch:
 			}
 
@@ -236,7 +236,7 @@ func (s *writerImpl) writeManyConsumer(ctx context.Context, callback func(uint32
 			var ch <-chan encodeResult
 			select {
 			case <-ctx.Done():
-				return nil
+				return ctx.Err()
 			case ch = <-queue:
 			}
 			if ch == nil {
@@ -247,7 +247,7 @@ func (s *writerImpl) writeManyConsumer(ctx context.Context, callback func(uint32
 			var result encodeResult
 			select {
 			case <-ctx.Done():
-				return nil
+				return ctx.Err()
 			case result = <-ch:
 			}
 
@@ -278,6 +278,9 @@ func (s *writerImpl) WriteMany(ctx context.Context, frameSource FrameSource, opt
 	}
 	if s.failed {
 		return errWriterFailed
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	opts := writeManyOptions{concurrency: runtime.GOMAXPROCS(0)}

--- a/pkg/writer_test.go
+++ b/pkg/writer_test.go
@@ -267,6 +267,39 @@ func TestFrameWriteFailureAllowsClose(t *testing.T) {
 	}
 }
 
+func TestConcurrentWriterCancellation(t *testing.T) {
+	t.Parallel()
+
+	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var b bytes.Buffer
+	w, err := NewWriter(&b, enc)
+	require.NoError(t, err)
+
+	err = w.WriteMany(ctx, makeTestFrameSource([][]byte{[]byte("test")}), WithConcurrency(1))
+	assert.ErrorIs(t, err, context.Canceled)
+
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	w, err = NewWriter(&b, enc)
+	require.NoError(t, err)
+
+	frames := [][]byte{}
+	for i := 0; i < 100; i++ {
+		frames = append(frames, []byte(fmt.Sprintf("test%d", i)))
+	}
+
+	err = w.WriteMany(ctx, makeTestFrameSource(frames), WithConcurrency(1), WithWriteCallback(func(uint32) {
+		cancel()
+	}))
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
 type fakeWriteEnvironment struct {
 	bw io.Writer
 }

--- a/pkg/writer_test.go
+++ b/pkg/writer_test.go
@@ -283,6 +283,16 @@ func TestConcurrentWriterCancellation(t *testing.T) {
 	err = w.WriteMany(ctx, makeTestFrameSource([][]byte{[]byte("test")}), WithConcurrency(1))
 	assert.ErrorIs(t, err, context.Canceled)
 
+	cause := errors.New("stop writing")
+	causeCtx, cancelCause := context.WithCancelCause(context.Background())
+	cancelCause(cause)
+
+	w, err = NewWriter(&b, enc)
+	require.NoError(t, err)
+
+	err = w.WriteMany(causeCtx, makeTestFrameSource([][]byte{[]byte("test")}), WithConcurrency(1))
+	assert.ErrorIs(t, err, cause)
+
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/writer_test.go
+++ b/pkg/writer_test.go
@@ -273,31 +273,13 @@ func TestConcurrentWriterCancellation(t *testing.T) {
 	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
 	var b bytes.Buffer
 	w, err := NewWriter(&b, enc)
 	require.NoError(t, err)
 
-	err = w.WriteMany(ctx, makeTestFrameSource([][]byte{[]byte("test")}), WithConcurrency(1))
-	assert.ErrorIs(t, err, context.Canceled)
-
 	cause := errors.New("stop writing")
-	causeCtx, cancelCause := context.WithCancelCause(context.Background())
-	cancelCause(cause)
-
-	w, err = NewWriter(&b, enc)
-	require.NoError(t, err)
-
-	err = w.WriteMany(causeCtx, makeTestFrameSource([][]byte{[]byte("test")}), WithConcurrency(1))
-	assert.ErrorIs(t, err, cause)
-
-	ctx, cancel = context.WithCancel(context.Background())
-	defer cancel()
-
-	w, err = NewWriter(&b, enc)
-	require.NoError(t, err)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
 
 	frames := [][]byte{}
 	for i := 0; i < 100; i++ {
@@ -305,9 +287,9 @@ func TestConcurrentWriterCancellation(t *testing.T) {
 	}
 
 	err = w.WriteMany(ctx, makeTestFrameSource(frames), WithConcurrency(1), WithWriteCallback(func(uint32) {
-		cancel()
+		cancel(cause)
 	}))
-	assert.ErrorIs(t, err, context.Canceled)
+	assert.ErrorIs(t, err, cause)
 }
 
 type fakeWriteEnvironment struct {


### PR DESCRIPTION
## Problem
`WriteMany` treated several `ctx.Done()` paths as successful exits. A canceled call could return `nil` after writing only part of the stream.

## Solution
Return `context.Cause(ctx)` from cancellation paths in the encoder, producer, and consumer goroutines. Also fail fast when `WriteMany` is called with an already-canceled context.

Fixes: https://github.com/SaveTheRbtz/zstd-seekable-format-go/pull/167