### PR TITLE
pkg: define reader post-close errors

### DIFF
--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -115,6 +115,8 @@ type readerImpl struct {
 	cachedFrame cachedFrame
 }
 
+var errReaderClosed = errors.New("reader is closed")
+
 var (
 	_ Reader      = (*readerImpl)(nil)
 	_ io.Seeker   = (*readerImpl)(nil)
@@ -174,6 +176,10 @@ func NewReader(rs io.ReadSeeker, decoder ZSTDDecoder, opts ...rOption) (Reader, 
 }
 
 func (r *readerImpl) ReadAt(p []byte, off int64) (n int, err error) {
+	if r.closed.Load() {
+		return 0, errReaderClosed
+	}
+
 	for m := 0; n < len(p) && err == nil; n += m {
 		_, m, err = r.read(p[n:], off+int64(n))
 	}
@@ -202,7 +208,7 @@ func (r *readerImpl) Close() error {
 
 func (r *readerImpl) read(dst []byte, off int64) (int64, int, error) {
 	if r.closed.Load() {
-		return 0, 0, fmt.Errorf("reader is closed")
+		return 0, 0, errReaderClosed
 	}
 
 	if off < 0 {
@@ -278,6 +284,10 @@ func (r *readerImpl) read(dst []byte, off int64) (int64, int, error) {
 }
 
 func (r *readerImpl) Seek(offset int64, whence int) (int64, error) {
+	if r.closed.Load() {
+		return 0, errReaderClosed
+	}
+
 	newOffset := r.offset
 	switch whence {
 	case io.SeekCurrent:

--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -199,7 +199,7 @@ func (r *readerImpl) Read(p []byte) (n int, err error) {
 }
 
 func (r *readerImpl) Close() error {
-	if r.closed.CompareAndSwap(false, true) {
+	if !r.closed.Swap(true) {
 		r.cachedFrame.replace(math.MaxUint64, nil)
 		r.seekTable = seekTable{}
 	}

--- a/pkg/reader_test.go
+++ b/pkg/reader_test.go
@@ -166,13 +166,61 @@ func TestReader(t *testing.T) {
 		err = r.Close()
 		require.NoError(t, err)
 
-		// read after close
-		_, err = r.Read(tmp)
-		require.ErrorContains(t, err, "reader is closed")
-
 		// double close
 		err = r.Close()
 		require.NoError(t, err)
+	}
+}
+
+func TestReaderPostCloseContract(t *testing.T) {
+	t.Parallel()
+
+	dec, err := zstd.NewReader(nil)
+	require.NoError(t, err)
+	defer dec.Close()
+
+	r, err := NewReader(&seekableBufferReaderAt{buf: checksum}, dec)
+	require.NoError(t, err)
+
+	err = r.Close()
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "Read",
+			call: func() error {
+				_, err := r.Read(make([]byte, 1))
+				return err
+			},
+		},
+		{
+			name: "ReadAt",
+			call: func() error {
+				_, err := r.ReadAt(make([]byte, 1), 0)
+				return err
+			},
+		},
+		{
+			name: "ReadAtEmpty",
+			call: func() error {
+				_, err := r.ReadAt(nil, 0)
+				return err
+			},
+		},
+		{
+			name: "Seek",
+			call: func() error {
+				_, err := r.Seek(0, io.SeekStart)
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.ErrorIs(t, tc.call(), errReaderClosed)
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a reader post-close contract test for `Read`, `ReadAt`, zero-length `ReadAt`, and `Seek`.
- Return a shared `errReaderClosed` sentinel from reader methods after `Close`.
- Fix `Seek` to reject calls after `Close` instead of using cleared reader state.

## Validation
- `env GOCACHE=/tmp/codex-go-build-cache go test -run 'TestReader(PostCloseContract)?$' ./...`
- `env GOCACHE=/tmp/codex-go-build-cache go test ./...`
- `env GOCACHE=/tmp/codex-go-build-cache go test -race ./...`
- `git diff --check`