### PR TITLE
pkg: release writer index on close

### DIFF
--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -130,6 +130,7 @@ func (s *writerImpl) Close() error {
 	}
 
 	err := s.writeSeekTable()
+	s.frameEntries = nil
 	s.env = nil
 	return err
 }

--- a/pkg/writer_test.go
+++ b/pkg/writer_test.go
@@ -307,11 +307,14 @@ func TestWriterCloseSemantics(t *testing.T) {
 	var b bytes.Buffer
 	w, err := NewWriter(&b, enc)
 	require.NoError(t, err)
+	sw := w.(*writerImpl)
 
 	_, err = w.Write([]byte("foo"))
 	require.NoError(t, err)
+	require.NotEmpty(t, sw.frameEntries)
 
 	require.NoError(t, w.Close())
+	assert.Nil(t, sw.frameEntries)
 
 	// double close should return an error
 	err = w.Close()


### PR DESCRIPTION
## Summary
- Clear `writerImpl.frameEntries` during `Close` after writing the seek table.
- Extend writer close semantics coverage to assert the in-memory index is released.

## Validation
- `env GOCACHE=/tmp/codex-go-build-cache go test -run 'TestWriterCloseSemantics$' ./...`
- `env GOCACHE=/tmp/codex-go-build-cache go test ./...`
- `env GOCACHE=/tmp/codex-go-build-cache go test -race ./...`
- `git diff --check`