### PR TITLE
go: remove toolchain directives

### DIFF
--- a/cmd/zstdseek/go.mod
+++ b/cmd/zstdseek/go.mod
@@ -2,8 +2,6 @@ module github.com/SaveTheRbtz/zstd-seekable-format-go/cmd/zstdseek
 
 go 1.25.0
 
-toolchain go1.26.3
-
 require (
 	github.com/SaveTheRbtz/fastcdc-go v0.3.0
 	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.0

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -2,8 +2,6 @@ module github.com/SaveTheRbtz/zstd-seekable-format-go/pkg
 
 go 1.25.0
 
-toolchain go1.26.3
-
 require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/klauspost/compress v1.18.6


### PR DESCRIPTION
## Summary
- Remove `toolchain go1.26.3` from both module files.
- Keep the existing `go 1.25.0` module directives unchanged.

## Validation
- `env GOCACHE=/tmp/codex-go-build-cache go test ./...` in `pkg`
- `env GOCACHE=/tmp/codex-go-build-cache go test ./...` in `cmd/zstdseek`
- `git diff --check`