### PR TITLE
ci: scan workflows with typos

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,6 +1,6 @@
 # Dependency Review Action
 #
-# This Action will scan dependency manifest files that change as part of a Pull Reqest, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
+# This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
 #
 # Source repository: https://github.com/actions/dependency-review-action
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -15,3 +15,5 @@ jobs:
       - uses: actions/checkout@v6
       - name: typos
         uses: crate-ci/typos@v1.47.0
+        with:
+          files: . .github


### PR DESCRIPTION
## Summary
- Configure the `typos` action to scan both `.` and `.github`.
- Fix the typo in `dependency-review.yml` that was hidden by the previous default scan scope.

## Validation
- `/tmp/codex-typos/bin/typos --format brief . .github`
- `git diff --check`