### PR TITLE
pkg: simplify checksum casts

### DIFF
--- a/pkg/encoder.go
+++ b/pkg/encoder.go
@@ -47,7 +47,7 @@ func (s *writerImpl) encodeOne(src []byte) ([]byte, seekTableEntry, error) {
 	return dst, seekTableEntry{
 		CompressedSize:   uint32(len(dst)),
 		DecompressedSize: uint32(len(src)),
-		Checksum:         uint32((xxhash.Sum64(src) << 32) >> 32),
+		Checksum:         uint32(xxhash.Sum64(src)),
 	}, nil
 }
 

--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -256,7 +256,7 @@ func (r *readerImpl) read(dst []byte, off int64) (int64, int, error) {
 		}
 
 		if r.checksums {
-			checksum := uint32((xxhash.Sum64(decompressed) << 32) >> 32)
+			checksum := uint32(xxhash.Sum64(decompressed))
 			if index.Checksum != checksum {
 				return 0, 0, fmt.Errorf("checksum verification failed at: %d: expected: %d, actual: %d",
 					index.CompOffset, index.Checksum, checksum)


### PR DESCRIPTION
## Summary
- Replace redundant `uint64` shift expressions with direct `uint32(xxhash.Sum64(...))` casts.
- Apply the cleanup in both checksum generation and verification.

## Validation
- `env GOCACHE=/tmp/codex-go-build-cache go test ./...`
- `env GOCACHE=/tmp/codex-go-build-cache go test -race ./...`
- `/tmp/codex-typos/bin/typos --format brief . .github`
- `git diff --check`