### PR TITLE
pkg: improve godoc comments

### DIFF
--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -1,6 +1,5 @@
 // Copyright (c) 2022, Alexey Ivanov
 // All rights reserved.
 
-// Package adds an ability create ZSTD files in seekable format
-// and randomly access them using uncompressed offsets.
+// Package seekable writes and reads Zstandard seekable-format streams.
 package seekable

--- a/pkg/encoder.go
+++ b/pkg/encoder.go
@@ -12,10 +12,11 @@ type Encoder interface {
 	// Encode returns compressed data and appends a frame to in-memory seek table.
 	Encode(src []byte) ([]byte, error)
 
-	// EndStream returns in-memory seek table as a ZSTD's skippable frame.
+	// EndStream returns the in-memory seek table as a Zstandard skippable frame.
 	EndStream() ([]byte, error)
 }
 
+// NewEncoder returns a byte-oriented encoder that uses encoder for Zstandard compression.
 func NewEncoder(encoder ZSTDEncoder, opts ...wOption) (Encoder, error) {
 	sw, err := NewWriter(nil, encoder, opts...)
 	if err != nil {

--- a/pkg/environments.go
+++ b/pkg/environments.go
@@ -1,7 +1,7 @@
 package seekable
 
-// WEnvironment can be used to inject a custom file writer that is different from normal WriteCloser.
-// This is useful when, for example there is custom chunking code.
+// WEnvironment is an advanced hook for custom storage implementations.
+// It can be used to write frames and seek tables somewhere other than a normal io.Writer.
 type WEnvironment interface {
 	// WriteFrame is called each time frame is encoded and needs to be written upstream.
 	WriteFrame(p []byte) (n int, err error)
@@ -9,8 +9,8 @@ type WEnvironment interface {
 	WriteSeekTable(p []byte) (n int, err error)
 }
 
-// REnvironment can be used to inject a custom file reader that is different from normal ReadSeeker.
-// This is useful when, for example there is custom chunking code.
+// REnvironment is an advanced hook for custom storage implementations.
+// It can be used to read frames and seek tables from somewhere other than a normal io.ReadSeeker.
 type REnvironment interface {
 	// GetFrameByIndex returns the compressed frame by its index.
 	GetFrameByIndex(index FrameOffsetEntry) ([]byte, error)

--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -130,7 +130,9 @@ type Reader interface {
 	io.Reader
 	io.ReaderAt
 	io.Seeker
-	io.Closer
+
+	// Close releases reader-owned memory and causes future Reader method calls to fail.
+	Close() error
 }
 
 // ZSTDDecoder is the decompressor.  Tested with github.com/klauspost/compress/zstd.
@@ -138,8 +140,8 @@ type ZSTDDecoder interface {
 	DecodeAll(input, dst []byte) ([]byte, error)
 }
 
-// NewReader returns ZSTD stream reader that can be randomly accessed using uncompressed data offset.
-// Ideally, passed io.ReadSeeker should implement io.ReaderAt interface.
+// NewReader returns a Zstandard stream reader that can be randomly accessed by uncompressed offset.
+// Ideally, rs should implement io.ReaderAt.
 func NewReader(rs io.ReadSeeker, decoder ZSTDDecoder, opts ...rOption) (Reader, error) {
 	sr := readerImpl{
 		dec: decoder,

--- a/pkg/reader_options.go
+++ b/pkg/reader_options.go
@@ -6,6 +6,7 @@ import (
 
 type rOption func(*readerImpl) error
 
+// WithRLogger sets the logger used by Reader internals.
 func WithRLogger(l *slog.Logger) rOption {
 	if l == nil {
 		l = discardLogger
@@ -13,6 +14,7 @@ func WithRLogger(l *slog.Logger) rOption {
 	return func(r *readerImpl) error { r.logger = l; return nil }
 }
 
+// WithREnvironment sets a custom read environment for advanced storage implementations.
 func WithREnvironment(e REnvironment) rOption {
 	return func(r *readerImpl) error { r.env = e; return nil }
 }

--- a/pkg/seek_table.go
+++ b/pkg/seek_table.go
@@ -8,7 +8,7 @@ type seekTable struct {
 }
 
 // NewSeekTable parses a seek table into random-access metadata.
-// The seek table can be produced by either Writer's WriteSeekTable or Encoder's EndStream.
+// The seek table can be the skippable frame written by Writer.Close or returned by Encoder.EndStream.
 // Lookup methods can be used concurrently.
 func NewSeekTable(buf []byte) (*seekTable, error) {
 	table, err := parseSeekTableFrame(buf)

--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -43,16 +43,16 @@ var (
 )
 
 type Writer interface {
-	// Write writes a chunk of data as a separate frame into the datastream.
+	// Write writes a chunk of data as a separate frame into the data stream.
 	//
 	// Note that Write does not do any coalescing nor splitting of data,
-	// so each write will map to a separate ZSTD Frame.
+	// so each write will map to a separate Zstandard frame.
 	Write(src []byte) (int, error)
 
-	// Close implement io.Closer interface.  It writes the seek table footer
-	// and releases occupied memory.
+	// Close implements io.Closer. It writes the seek table, releases the in-memory
+	// frame index, and causes future Writer method calls to fail.
 	//
-	// Caller is still responsible to Close the underlying writer.
+	// The caller is still responsible for closing the underlying writer.
 	Close() (err error)
 }
 
@@ -60,11 +60,11 @@ type Writer interface {
 // When there are no more frames, returns nil.
 type FrameSource func() ([]byte, error)
 
-// ConcurrentWriter allows writing many frames concurrently
+// ConcurrentWriter allows writing many frames concurrently.
 type ConcurrentWriter interface {
 	Writer
 
-	// WriteMany writes many frames concurrently
+	// WriteMany writes many frames concurrently.
 	WriteMany(ctx context.Context, frameSource FrameSource, options ...WriteManyOption) error
 }
 
@@ -73,8 +73,8 @@ type ZSTDEncoder interface {
 	EncodeAll(src, dst []byte) []byte
 }
 
-// NewWriter wraps the passed io.Writer and Encoder into and indexed ZSTD stream.
-// Resulting stream then can be randomly accessed through Reader or NewSeekTable.
+// NewWriter wraps w and encoder into an indexed Zstandard stream.
+// The resulting stream can be randomly accessed through Reader or NewSeekTable.
 func NewWriter(w io.Writer, encoder ZSTDEncoder, opts ...wOption) (ConcurrentWriter, error) {
 	sw := writerImpl{
 		enc: encoder,

--- a/pkg/writer_options.go
+++ b/pkg/writer_options.go
@@ -7,6 +7,7 @@ import (
 
 type wOption func(*writerImpl) error
 
+// WithWLogger sets the logger used by Writer and Encoder internals.
 func WithWLogger(l *slog.Logger) wOption {
 	if l == nil {
 		l = discardLogger
@@ -14,6 +15,7 @@ func WithWLogger(l *slog.Logger) wOption {
 	return func(w *writerImpl) error { w.logger = l; return nil }
 }
 
+// WithWEnvironment sets a custom write environment for advanced storage implementations.
 func WithWEnvironment(e WEnvironment) wOption {
 	return func(w *writerImpl) error { w.env = e; return nil }
 }
@@ -25,6 +27,7 @@ type writeManyOptions struct {
 
 type WriteManyOption func(options *writeManyOptions) error
 
+// WithConcurrency sets the maximum number of concurrent frame encoding operations.
 func WithConcurrency(concurrency int) WriteManyOption {
 	return func(options *writeManyOptions) error {
 		if concurrency < 1 {
@@ -35,6 +38,7 @@ func WithConcurrency(concurrency int) WriteManyOption {
 	}
 }
 
+// WithWriteCallback calls cb after each frame is written, passing the decompressed frame size.
 func WithWriteCallback(cb func(size uint32)) WriteManyOption {
 	return func(options *writeManyOptions) error {
 		options.writeCallback = cb


### PR DESCRIPTION
## Summary
- Clarify package, reader/writer lifecycle, seek-table, encoder, and environment comments.
- Add missing comments for exported option helpers and `NewEncoder`.
- Tighten wording around Zstandard streams, frames, and close behavior.

## Validation
- `go doc -all .`
- `env GOCACHE=/tmp/codex-go-build-cache go test ./...`
- `env GOCACHE=/tmp/codex-go-build-cache go test -race ./...`
- `/tmp/codex-typos/bin/typos --format brief . .github`
- `git diff --check`