### PR TITLE
pkg: export SeekTable type

### DIFF
--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -102,7 +102,7 @@ func (rs *readSeekerEnvImpl) ReadSkipFrame(skippableFrameOffset int64) ([]byte, 
 
 type readerImpl struct {
 	dec ZSTDDecoder
-	seekTable
+	SeekTable
 
 	offset int64
 
@@ -172,7 +172,7 @@ func NewReader(rs io.ReadSeeker, decoder ZSTDDecoder, opts ...rOption) (Reader, 
 		return nil, fmt.Errorf("decompressed size is too large for Reader: %d > %d", table.Size(), maxReaderOffset)
 	}
 
-	sr.seekTable = table
+	sr.SeekTable = table
 
 	return &sr, nil
 }
@@ -203,7 +203,7 @@ func (r *readerImpl) Read(p []byte) (n int, err error) {
 func (r *readerImpl) Close() error {
 	if !r.closed.Swap(true) {
 		r.cachedFrame.replace(math.MaxUint64, nil)
-		r.seekTable = seekTable{}
+		r.SeekTable = SeekTable{}
 	}
 	return nil
 }

--- a/pkg/seek_table.go
+++ b/pkg/seek_table.go
@@ -2,36 +2,18 @@ package seekable
 
 import "sort"
 
-type seekTable struct {
+// SeekTable is parsed random-access metadata from a Zstandard seek-table skippable frame.
+//
+// Use NewSeekTable to construct a SeekTable from bytes written by Writer.Close
+// or returned by Encoder.EndStream. Lookup methods can be used concurrently.
+type SeekTable struct {
 	entries   []FrameOffsetEntry
 	checksums bool
 }
 
-// SeekTable provides random-access metadata parsed from a Zstandard seek-table skippable frame.
-//
-// Use NewSeekTable to construct a SeekTable from bytes written by Writer.Close
-// or returned by Encoder.EndStream. Lookup methods can be used concurrently.
-type SeekTable interface {
-	// Size returns the size of the decompressed stream.
-	Size() uint64
-
-	// NumFrames returns the number of frames in the seek table.
-	NumFrames() int64
-
-	// EntryByDecompressedOffset returns the frame containing off in the decompressed stream.
-	// It returns false if off is greater than or equal to Size().
-	EntryByDecompressedOffset(off uint64) (FrameOffsetEntry, bool)
-
-	// EntryByID returns the frame with id.
-	// It returns false if id is greater than or equal to NumFrames() or less than 0.
-	EntryByID(id int64) (FrameOffsetEntry, bool)
-}
-
-var _ SeekTable = (*seekTable)(nil)
-
 // NewSeekTable parses the seek-table skippable frame written by Writer.Close
 // or returned by Encoder.EndStream.
-func NewSeekTable(buf []byte) (SeekTable, error) {
+func NewSeekTable(buf []byte) (*SeekTable, error) {
 	table, err := parseSeekTableFrame(buf)
 	if err != nil {
 		return nil, err
@@ -40,7 +22,8 @@ func NewSeekTable(buf []byte) (SeekTable, error) {
 	return &table, nil
 }
 
-func (t seekTable) Size() uint64 {
+// Size returns the size of the decompressed stream.
+func (t SeekTable) Size() uint64 {
 	if len(t.entries) == 0 {
 		return 0
 	}
@@ -49,11 +32,14 @@ func (t seekTable) Size() uint64 {
 	return last.DecompOffset + uint64(last.DecompSize)
 }
 
-func (t seekTable) NumFrames() int64 {
+// NumFrames returns the number of frames in the seek table.
+func (t SeekTable) NumFrames() int64 {
 	return int64(len(t.entries))
 }
 
-func (t seekTable) EntryByDecompressedOffset(off uint64) (FrameOffsetEntry, bool) {
+// EntryByDecompressedOffset returns the frame containing off in the decompressed stream.
+// It returns false if off is greater than or equal to Size().
+func (t SeekTable) EntryByDecompressedOffset(off uint64) (FrameOffsetEntry, bool) {
 	if off >= t.Size() {
 		return FrameOffsetEntry{}, false
 	}
@@ -69,7 +55,9 @@ func (t seekTable) EntryByDecompressedOffset(off uint64) (FrameOffsetEntry, bool
 	return t.entries[n], true
 }
 
-func (t seekTable) EntryByID(id int64) (FrameOffsetEntry, bool) {
+// EntryByID returns the frame with id.
+// It returns false if id is greater than or equal to NumFrames() or less than 0.
+func (t SeekTable) EntryByID(id int64) (FrameOffsetEntry, bool) {
 	if id < 0 || id >= int64(len(t.entries)) {
 		return FrameOffsetEntry{}, false
 	}

--- a/pkg/seek_table.go
+++ b/pkg/seek_table.go
@@ -7,10 +7,31 @@ type seekTable struct {
 	checksums bool
 }
 
-// NewSeekTable parses a seek table into random-access metadata.
-// The seek table can be the skippable frame written by Writer.Close or returned by Encoder.EndStream.
-// Lookup methods can be used concurrently.
-func NewSeekTable(buf []byte) (*seekTable, error) {
+// SeekTable provides random-access metadata parsed from a Zstandard seek-table skippable frame.
+//
+// Use NewSeekTable to construct a SeekTable from bytes written by Writer.Close
+// or returned by Encoder.EndStream. Lookup methods can be used concurrently.
+type SeekTable interface {
+	// Size returns the size of the decompressed stream.
+	Size() uint64
+
+	// NumFrames returns the number of frames in the seek table.
+	NumFrames() int64
+
+	// EntryByDecompressedOffset returns the frame containing off in the decompressed stream.
+	// It returns false if off is greater than or equal to Size().
+	EntryByDecompressedOffset(off uint64) (FrameOffsetEntry, bool)
+
+	// EntryByID returns the frame with id.
+	// It returns false if id is greater than or equal to NumFrames() or less than 0.
+	EntryByID(id int64) (FrameOffsetEntry, bool)
+}
+
+var _ SeekTable = (*seekTable)(nil)
+
+// NewSeekTable parses the seek-table skippable frame written by Writer.Close
+// or returned by Encoder.EndStream.
+func NewSeekTable(buf []byte) (SeekTable, error) {
 	table, err := parseSeekTableFrame(buf)
 	if err != nil {
 		return nil, err
@@ -32,8 +53,6 @@ func (t seekTable) NumFrames() int64 {
 	return int64(len(t.entries))
 }
 
-// EntryByDecompressedOffset returns the frame containing off in the decompressed stream.
-// It returns false if off is greater than or equal to Size().
 func (t seekTable) EntryByDecompressedOffset(off uint64) (FrameOffsetEntry, bool) {
 	if off >= t.Size() {
 		return FrameOffsetEntry{}, false
@@ -50,8 +69,6 @@ func (t seekTable) EntryByDecompressedOffset(off uint64) (FrameOffsetEntry, bool
 	return t.entries[n], true
 }
 
-// EntryByID returns the frame with id.
-// It returns false if id is greater than or equal to NumFrames() or less than 0.
 func (t seekTable) EntryByID(id int64) (FrameOffsetEntry, bool) {
 	if id < 0 || id >= int64(len(t.entries)) {
 		return FrameOffsetEntry{}, false

--- a/pkg/seek_table.go
+++ b/pkg/seek_table.go
@@ -37,6 +37,11 @@ func (t SeekTable) NumFrames() int64 {
 	return int64(len(t.entries))
 }
 
+// HasChecksums reports whether entries in the seek table include checksum fields.
+func (t SeekTable) HasChecksums() bool {
+	return t.checksums
+}
+
 // EntryByDecompressedOffset returns the frame containing off in the decompressed stream.
 // It returns false if off is greater than or equal to Size().
 func (t SeekTable) EntryByDecompressedOffset(off uint64) (FrameOffsetEntry, bool) {

--- a/pkg/seek_table_benchmark_test.go
+++ b/pkg/seek_table_benchmark_test.go
@@ -14,7 +14,7 @@ var seekTableBenchmarkSizes = []struct {
 }
 
 var (
-	benchmarkSeekTableSink *seekTable
+	benchmarkSeekTableSink SeekTable
 	benchmarkEntrySink     FrameOffsetEntry
 	benchmarkBoolSink      bool
 	benchmarkIntSink       int64
@@ -46,7 +46,7 @@ func benchmarkSeekTable(b testing.TB, frameCount int) []byte {
 	return frame
 }
 
-func benchmarkParsedSeekTable(b *testing.B, frameCount int) *seekTable {
+func benchmarkParsedSeekTable(b *testing.B, frameCount int) SeekTable {
 	b.Helper()
 
 	seekTable := benchmarkSeekTable(b, frameCount)

--- a/pkg/seek_table_benchmark_test.go
+++ b/pkg/seek_table_benchmark_test.go
@@ -14,7 +14,7 @@ var seekTableBenchmarkSizes = []struct {
 }
 
 var (
-	benchmarkSeekTableSink SeekTable
+	benchmarkSeekTableSink *SeekTable
 	benchmarkEntrySink     FrameOffsetEntry
 	benchmarkBoolSink      bool
 	benchmarkIntSink       int64
@@ -46,7 +46,7 @@ func benchmarkSeekTable(b testing.TB, frameCount int) []byte {
 	return frame
 }
 
-func benchmarkParsedSeekTable(b *testing.B, frameCount int) SeekTable {
+func benchmarkParsedSeekTable(b *testing.B, frameCount int) *SeekTable {
 	b.Helper()
 
 	seekTable := benchmarkSeekTable(b, frameCount)

--- a/pkg/seek_table_parser.go
+++ b/pkg/seek_table_parser.go
@@ -7,58 +7,58 @@ import (
 
 const skippableFrameHeaderSize = frameSizeFieldSize + skippableMagicNumberFieldSize
 
-func readSeekTable(renv REnvironment) (seekTable, error) {
+func readSeekTable(renv REnvironment) (SeekTable, error) {
 	footerBuf, err := renv.ReadFooter()
 	if err != nil {
-		return seekTable{}, fmt.Errorf("failed to read footer: %w", err)
+		return SeekTable{}, fmt.Errorf("failed to read footer: %w", err)
 	}
 
 	footer, entrySize, err := parseSeekTableFooter(footerBuf)
 	if err != nil {
-		return seekTable{}, err
+		return SeekTable{}, err
 	}
 
 	frameOffset, err := seekTableFrameOffset(footer, entrySize)
 	if err != nil {
-		return seekTable{}, err
+		return SeekTable{}, err
 	}
 
 	frameBuf, err := renv.ReadSkipFrame(frameOffset)
 	if err != nil {
-		return seekTable{}, fmt.Errorf("failed to read seek table frame: %w", err)
+		return SeekTable{}, fmt.Errorf("failed to read seek table frame: %w", err)
 	}
 
 	return parseSeekTableFrame(frameBuf)
 }
 
-func parseSeekTableFrame(buf []byte) (seekTable, error) {
+func parseSeekTableFrame(buf []byte) (SeekTable, error) {
 	footer, entrySize, err := parseSeekTableFooter(buf)
 	if err != nil {
-		return seekTable{}, err
+		return SeekTable{}, err
 	}
 	if _, err := seekTableFrameOffset(footer, entrySize); err != nil {
-		return seekTable{}, err
+		return SeekTable{}, err
 	}
 
 	if len(buf) < skippableFrameHeaderSize+seekTableFooterOffset {
-		return seekTable{}, fmt.Errorf("skip frame is too small: %d", len(buf))
+		return SeekTable{}, fmt.Errorf("skip frame is too small: %d", len(buf))
 	}
 
 	magic := binary.LittleEndian.Uint32(buf[0:4])
 	if magic != skippableFrameMagic+seekableTag {
-		return seekTable{}, fmt.Errorf("skippable frame magic mismatch %d vs %d",
+		return SeekTable{}, fmt.Errorf("skippable frame magic mismatch %d vs %d",
 			magic, skippableFrameMagic+seekableTag)
 	}
 
 	expectedFrameSize := int64(len(buf)) - skippableFrameHeaderSize
 	frameSize := int64(binary.LittleEndian.Uint32(buf[4:8]))
 	if frameSize != expectedFrameSize {
-		return seekTable{}, fmt.Errorf("skippable frame size mismatch: expected: %d, actual: %d",
+		return SeekTable{}, fmt.Errorf("skippable frame size mismatch: expected: %d, actual: %d",
 			expectedFrameSize, frameSize)
 	}
 
 	if frameSize > maxDecoderFrameSize {
-		return seekTable{}, fmt.Errorf("frame is too big: %d > %d", frameSize, maxDecoderFrameSize)
+		return SeekTable{}, fmt.Errorf("frame is too big: %d > %d", frameSize, maxDecoderFrameSize)
 	}
 
 	entries, err := parseSeekTableEntries(
@@ -67,10 +67,10 @@ func parseSeekTableFrame(buf []byte) (seekTable, error) {
 		footer.NumberOfFrames,
 	)
 	if err != nil {
-		return seekTable{}, err
+		return SeekTable{}, err
 	}
 
-	return seekTable{
+	return SeekTable{
 		entries:   entries,
 		checksums: footer.SeekTableDescriptor.ChecksumFlag,
 	}, nil

--- a/pkg/seek_table_test.go
+++ b/pkg/seek_table_test.go
@@ -20,6 +20,7 @@ func TestNewSeekTable(t *testing.T) {
 
 	assert.Equal(t, uint64(len(sourceString)), table.Size())
 	assert.Equal(t, int64(2), table.NumFrames())
+	assert.True(t, table.HasChecksums())
 
 	for id, tc := range []struct {
 		name    string
@@ -57,4 +58,8 @@ func TestNewSeekTable(t *testing.T) {
 		_, ok := table.EntryByID(id)
 		assert.False(t, ok)
 	}
+
+	noChecksumTable, err := NewSeekTable(noChecksum[17+18:])
+	require.NoError(t, err)
+	assert.False(t, noChecksumTable.HasChecksums())
 }


### PR DESCRIPTION
## Problem
- `NewSeekTable` returned a private concrete type, so callers could use the value but could not name the parsed seek-table type in their own APIs.
- Returning a producer-owned interface would be harder to evolve: adding methods later would break any external implementation even though the package has only one parsed table representation.
- `FrameOffsetEntry.Checksum` is visible, but callers could not tell whether checksum fields were present or whether the value was zero because checksums were absent.

## Solution
- Export concrete `SeekTable` with unexported fields.
- Return `*SeekTable` from `NewSeekTable` so construction still goes through the parser.
- Add `SeekTable.HasChecksums()` to make checksum metadata explicit.
- Keep reader behavior separate from seek-table metadata lookup.

## API
- `NewSeekTable(buf []byte) (*seekTable, error)` is now `NewSeekTable(buf []byte) (*SeekTable, error)`.
- `SeekTable` exposes `Size`, `NumFrames`, `HasChecksums`, `EntryByID`, and `EntryByDecompressedOffset` methods.

## Validation
- `go doc . SeekTable`
- `go doc . NewSeekTable`
- `env GOCACHE=/tmp/codex-go-build-cache go test ./...`
- `env GOCACHE=/tmp/codex-go-build-cache go test -race ./...`
- `/tmp/codex-typos/bin/typos --format brief . .github`
- `git diff --check`