### PR TITLE
pkg: improve godoc comments

### DIFF
--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -1,5 +1,18 @@
 // Copyright (c) 2022, Alexey Ivanov
 // All rights reserved.
 
-// Package seekable writes and reads Zstandard seekable-format streams.
+// Package seekable writes and reads streams using the Zstandard seekable format.
+//
+// A seekable stream is a valid Zstandard stream made from one or more
+// compressed frames followed by a final skippable frame containing a seek table.
+// Standard Zstandard decoders can read the stream from the beginning, while
+// Reader uses the seek table to serve Read, ReadAt, and Seek calls by
+// uncompressed byte offset.
+//
+// Writer and Encoder produce seekable streams by storing each non-empty input
+// chunk as a separate Zstandard frame. Close or EndStream must be called to
+// append or retrieve the final seek-table skippable frame.
+//
+// The package accepts small encoder and decoder interfaces and is tested with
+// github.com/klauspost/compress/zstd.
 package seekable

--- a/pkg/encoder.go
+++ b/pkg/encoder.go
@@ -8,8 +8,14 @@ import (
 )
 
 // Encoder is a byte-oriented API that is useful where wrapping io.Writer is not desirable.
+//
+// Each non-empty Encode call returns one compressed Zstandard frame and appends
+// one entry to the in-memory seek table. EndStream returns the final seek-table
+// skippable frame, which must be appended after all encoded frames to form a
+// complete seekable stream.
 type Encoder interface {
 	// Encode returns compressed data and appends a frame to in-memory seek table.
+	// Empty inputs return an empty slice and do not add seek-table entries.
 	Encode(src []byte) ([]byte, error)
 
 	// EndStream returns the in-memory seek table as a Zstandard skippable frame.
@@ -17,6 +23,8 @@ type Encoder interface {
 }
 
 // NewEncoder returns a byte-oriented encoder that uses encoder for Zstandard compression.
+//
+// The caller remains responsible for closing encoder, if it requires closing.
 func NewEncoder(encoder ZSTDEncoder, opts ...wOption) (Encoder, error) {
 	sw, err := NewWriter(nil, encoder, opts...)
 	if err != nil {

--- a/pkg/environments.go
+++ b/pkg/environments.go
@@ -3,20 +3,36 @@ package seekable
 // WEnvironment is an advanced hook for custom storage implementations.
 // It can be used to write frames and seek tables somewhere other than a normal io.Writer.
 type WEnvironment interface {
-	// WriteFrame is called each time frame is encoded and needs to be written upstream.
+	// WriteFrame writes one complete compressed Zstandard frame.
+	//
+	// It is called once for each non-empty frame, in stream order. It should
+	// follow io.Writer conventions and return len(p), nil after a complete write.
 	WriteFrame(p []byte) (n int, err error)
-	// WriteSeekTable is called on Close to flush the seek table.
+
+	// WriteSeekTable writes the final seek-table skippable frame.
+	//
+	// p includes the skippable-frame magic number, frame-size field, seek-table
+	// entries, and seek-table footer. It should follow io.Writer conventions and
+	// return len(p), nil after a complete write.
 	WriteSeekTable(p []byte) (n int, err error)
 }
 
 // REnvironment is an advanced hook for custom storage implementations.
 // It can be used to read frames and seek tables from somewhere other than a normal io.ReadSeeker.
 type REnvironment interface {
-	// GetFrameByIndex returns the compressed frame by its index.
+	// GetFrameByIndex returns one complete compressed frame by seek-table entry.
+	//
+	// The returned slice must contain exactly index.CompSize bytes starting at
+	// index.CompOffset in the compressed stream.
 	GetFrameByIndex(index FrameOffsetEntry) ([]byte, error)
-	// ReadFooter returns buffer whose last 9 bytes are interpreted as a `Seek_Table_Footer`.
+
+	// ReadFooter returns bytes whose last 9 bytes are interpreted as a Seek_Table_Footer.
 	ReadFooter() ([]byte, error)
-	// ReadSkipFrame returns the full Seek Table Skippable frame
-	// including the `Skippable_Magic_Number` and `Frame_Size`.
+
+	// ReadSkipFrame returns the full final seek-table skippable frame.
+	//
+	// skippableFrameOffset is the number of bytes from the end of the stream
+	// back to the start of the final skippable frame. The returned bytes must
+	// include the Skippable_Magic_Number and Frame_Size fields.
 	ReadSkipFrame(skippableFrameOffset int64) ([]byte, error)
 }

--- a/pkg/example_test.go
+++ b/pkg/example_test.go
@@ -1,94 +1,54 @@
 package seekable_test
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"log"
-	"os"
 
 	"github.com/klauspost/compress/zstd"
 
 	seekable "github.com/SaveTheRbtz/zstd-seekable-format-go/pkg"
 )
 
-func Example() {
-	f, err := os.CreateTemp("", "example")
-	if err != nil {
-		log.Fatal(err)
+func exampleFrames() [][]byte {
+	return [][]byte{[]byte("Hello"), []byte(" "), []byte("World!")}
+}
+
+func writeExampleFrames(w seekable.Writer) {
+	for _, frame := range exampleFrames() {
+		if _, err := w.Write(frame); err != nil {
+			log.Fatal(err)
+		}
 	}
-	defer func() {
-		_ = os.Remove(f.Name())
-	}()
+}
+
+func exampleSeekableStream() []byte {
+	var buf bytes.Buffer
 
 	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer func() {
-		_ = enc.Close()
-	}()
+	defer enc.Close()
 
-	w, err := seekable.NewWriter(f, enc)
+	w, err := seekable.NewWriter(&buf, enc)
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	// Write data in chunks.
-	for _, b := range [][]byte{[]byte("Hello"), []byte(" "), []byte("World!")} {
-		_, err = w.Write(b)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
-
-	// Close and flush seek table.
-	err = w.Close()
-	if err != nil {
+	writeExampleFrames(w)
+	if err := w.Close(); err != nil {
 		log.Fatal(err)
 	}
 
-	dec, err := zstd.NewReader(nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer dec.Close()
+	return buf.Bytes()
+}
 
-	r, err := seekable.NewReader(f, dec)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer func() {
-		_ = r.Close()
-	}()
+func ExampleNewWriter() {
+	compressed := exampleSeekableStream()
 
-	ello := make([]byte, 4)
-	// ReaderAt
-	_, err = r.ReadAt(ello, 1)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Printf("Offset: 1 from the start: %s\n", string(ello))
-
-	world := make([]byte, 5)
-	// Seeker
-	_, err = r.Seek(-6, io.SeekEnd)
-	if err != nil {
-		log.Fatal(err)
-	}
-	// Reader
-	_, err = r.Read(world)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Printf("Offset: -6 from the end: %s\n", string(world))
-
-	_, err = f.Seek(0, io.SeekStart)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Standard ZSTD Reader.
-	dec, err = zstd.NewReader(f)
+	dec, err := zstd.NewReader(bytes.NewReader(compressed))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -98,11 +58,127 @@ func Example() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	fmt.Printf("Whole string: %s\n", string(all))
+	fmt.Println(string(all))
 
 	// Output:
-	// Offset: 1 from the start: ello
-	// Offset: -6 from the end: World
-	// Whole string: Hello World!
+	// Hello World!
+}
+
+func ExampleNewReader() {
+	compressed := exampleSeekableStream()
+
+	dec, err := zstd.NewReader(nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer dec.Close()
+
+	r, err := seekable.NewReader(bytes.NewReader(compressed), dec)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		_ = r.Close()
+	}()
+
+	ello := make([]byte, 4)
+	if _, err := r.ReadAt(ello, 1); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(ello))
+
+	world := make([]byte, 5)
+	if _, err := r.Seek(-6, io.SeekEnd); err != nil {
+		log.Fatal(err)
+	}
+	if _, err := r.Read(world); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(world))
+
+	// Output:
+	// ello
+	// World
+}
+
+func ExampleNewSeekTable() {
+	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer enc.Close()
+
+	e, err := seekable.NewEncoder(enc)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if _, err := e.Encode([]byte("Hello")); err != nil {
+		log.Fatal(err)
+	}
+	if _, err := e.Encode([]byte(" World!")); err != nil {
+		log.Fatal(err)
+	}
+
+	seekTableFrame, err := e.EndStream()
+	if err != nil {
+		log.Fatal(err)
+	}
+	table, err := seekable.NewSeekTable(seekTableFrame)
+	if err != nil {
+		log.Fatal(err)
+	}
+	entry, ok := table.EntryByDecompressedOffset(7)
+	if !ok {
+		log.Fatal("missing seek-table entry")
+	}
+
+	fmt.Printf("frames=%d size=%d checksums=%t\n", table.NumFrames(), table.Size(), table.HasChecksums())
+	fmt.Printf("offset 7 is in frame %d\n", entry.ID)
+
+	// Output:
+	// frames=2 size=12 checksums=true
+	// offset 7 is in frame 1
+}
+
+func ExampleConcurrentWriter_WriteMany() {
+	var buf bytes.Buffer
+
+	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer enc.Close()
+
+	w, err := seekable.NewWriter(&buf, enc)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	frames := exampleFrames()
+	next := func() ([]byte, error) {
+		if len(frames) == 0 {
+			return nil, nil
+		}
+		frame := frames[0]
+		frames = frames[1:]
+		return frame, nil
+	}
+
+	err = w.WriteMany(context.Background(), next,
+		seekable.WithConcurrency(2),
+		seekable.WithWriteCallback(func(size uint32) {
+			fmt.Println(size)
+		}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// 5
+	// 1
+	// 6
 }

--- a/pkg/example_test.go
+++ b/pkg/example_test.go
@@ -31,7 +31,11 @@ func exampleSeekableStream() []byte {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer enc.Close()
+	defer func() {
+		if err := enc.Close(); err != nil {
+			log.Fatal(err)
+		}
+	}()
 
 	w, err := seekable.NewWriter(&buf, enc)
 	if err != nil {
@@ -106,7 +110,11 @@ func ExampleNewSeekTable() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer enc.Close()
+	defer func() {
+		if err := enc.Close(); err != nil {
+			log.Fatal(err)
+		}
+	}()
 
 	e, err := seekable.NewEncoder(enc)
 	if err != nil {
@@ -147,7 +155,11 @@ func ExampleConcurrentWriter_WriteMany() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer enc.Close()
+	defer func() {
+		if err := enc.Close(); err != nil {
+			log.Fatal(err)
+		}
+	}()
 
 	w, err := seekable.NewWriter(&buf, enc)
 	if err != nil {

--- a/pkg/frame_offset.go
+++ b/pkg/frame_offset.go
@@ -7,13 +7,13 @@ type FrameOffsetEntry struct {
 	// ID is the sequence number of the frame in the index.
 	ID int64
 
-	// CompOffset is the offset within compressed stream.
+	// CompOffset is the offset within the compressed stream.
 	CompOffset uint64
-	// DecompOffset is the offset within decompressed stream.
+	// DecompOffset is the offset within the decompressed stream.
 	DecompOffset uint64
 	// CompSize is the size of the compressed frame.
 	CompSize uint32
-	// DecompSize is the size of the original data.
+	// DecompSize is the size of the frame's decompressed data.
 	DecompSize uint32
 
 	// Checksum is the lower 32 bits of the XXH64 hash of the uncompressed data.

--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -125,7 +125,10 @@ var (
 	_ io.Closer   = (*readerImpl)(nil)
 )
 
-// Reader provides sequential and random access to a seekable ZSTD stream.
+// Reader provides sequential and random access to a seekable Zstandard stream.
+//
+// Offsets are expressed in the decompressed stream. Read and Seek use an
+// internal current offset; ReadAt does not.
 type Reader interface {
 	io.Reader
 	io.ReaderAt
@@ -135,13 +138,22 @@ type Reader interface {
 	Close() error
 }
 
-// ZSTDDecoder is the decompressor.  Tested with github.com/klauspost/compress/zstd.
+// ZSTDDecoder is the decompressor.
+//
+// It is compatible with the DecodeAll method provided by
+// github.com/klauspost/compress/zstd.
 type ZSTDDecoder interface {
 	DecodeAll(input, dst []byte) ([]byte, error)
 }
 
 // NewReader returns a Zstandard stream reader that can be randomly accessed by uncompressed offset.
-// Ideally, rs should implement io.ReaderAt.
+//
+// The stream must contain a final seek-table skippable frame. rs must be
+// non-nil unless WithREnvironment supplies a custom read environment. If rs
+// also implements io.ReaderAt, frame reads do not move rs's current offset.
+//
+// NewReader reads and validates the seek table during construction. The caller
+// remains responsible for closing rs and decoder, if they require closing.
 func NewReader(rs io.ReadSeeker, decoder ZSTDDecoder, opts ...rOption) (Reader, error) {
 	sr := readerImpl{
 		dec: decoder,

--- a/pkg/reader_options.go
+++ b/pkg/reader_options.go
@@ -7,6 +7,8 @@ import (
 type rOption func(*readerImpl) error
 
 // WithRLogger sets the logger used by Reader internals.
+//
+// Passing nil restores the default discard logger.
 func WithRLogger(l *slog.Logger) rOption {
 	if l == nil {
 		l = discardLogger
@@ -15,6 +17,9 @@ func WithRLogger(l *slog.Logger) rOption {
 }
 
 // WithREnvironment sets a custom read environment for advanced storage implementations.
+//
+// When this option is supplied, NewReader uses e instead of the io.ReadSeeker
+// argument for all seek-table and frame reads.
 func WithREnvironment(e REnvironment) rOption {
 	return func(r *readerImpl) error { r.env = e; return nil }
 }

--- a/pkg/seek_table.go
+++ b/pkg/seek_table.go
@@ -4,15 +4,20 @@ import "sort"
 
 // SeekTable is parsed random-access metadata from a Zstandard seek-table skippable frame.
 //
-// Use NewSeekTable to construct a SeekTable from bytes written by Writer.Close
-// or returned by Encoder.EndStream. Lookup methods can be used concurrently.
+// Use NewSeekTable to construct a SeekTable from bytes written through
+// WEnvironment.WriteSeekTable or returned by Encoder.EndStream. Lookup methods
+// can be used concurrently.
 type SeekTable struct {
 	entries   []FrameOffsetEntry
 	checksums bool
 }
 
-// NewSeekTable parses the seek-table skippable frame written by Writer.Close
-// or returned by Encoder.EndStream.
+// NewSeekTable parses a seek-table skippable frame.
+//
+// buf must contain the final seek-table skippable frame itself, including the
+// skippable-frame magic number and frame-size header. This is the byte sequence
+// returned by Encoder.EndStream or passed to WEnvironment.WriteSeekTable, not
+// the whole compressed stream.
 func NewSeekTable(buf []byte) (*SeekTable, error) {
 	table, err := parseSeekTableFrame(buf)
 	if err != nil {

--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -42,11 +42,17 @@ var (
 	_ io.Closer = (*writerImpl)(nil)
 )
 
+// Writer writes a seekable Zstandard stream.
+//
+// Each non-empty Write call becomes one Zstandard frame in the output stream.
+// Close must be called to write the final seek-table skippable frame; without
+// it, Reader and NewSeekTable cannot find the random-access metadata.
 type Writer interface {
 	// Write writes a chunk of data as a separate frame into the data stream.
 	//
 	// Note that Write does not do any coalescing nor splitting of data,
-	// so each write will map to a separate Zstandard frame.
+	// so each non-empty write will map to a separate Zstandard frame.
+	// Empty writes do not add seek-table entries.
 	Write(src []byte) (int, error)
 
 	// Close implements io.Closer. It writes the seek table, releases the in-memory
@@ -57,7 +63,9 @@ type Writer interface {
 }
 
 // FrameSource returns one frame of data at a time.
-// When there are no more frames, returns nil.
+//
+// When there are no more frames, it returns nil, nil. A non-nil error stops the
+// write. Empty frames are ignored by ConcurrentWriter.WriteMany.
 type FrameSource func() ([]byte, error)
 
 // ConcurrentWriter allows writing many frames concurrently.
@@ -65,15 +73,28 @@ type ConcurrentWriter interface {
 	Writer
 
 	// WriteMany writes many frames concurrently.
+	//
+	// It reads frames from frameSource sequentially, compresses up to the
+	// configured concurrency in parallel, and writes compressed frames in the
+	// same order returned by frameSource. Close must still be called after a
+	// successful WriteMany call to write the final seek table.
 	WriteMany(ctx context.Context, frameSource FrameSource, options ...WriteManyOption) error
 }
 
-// ZSTDEncoder is the compressor.  Tested with github.com/klauspost/compress/zstd.
+// ZSTDEncoder is the compressor.
+//
+// It is compatible with the EncodeAll method provided by
+// github.com/klauspost/compress/zstd.
 type ZSTDEncoder interface {
 	EncodeAll(src, dst []byte) []byte
 }
 
 // NewWriter wraps w and encoder into an indexed Zstandard stream.
+//
+// w must be non-nil unless WithWEnvironment supplies a custom write
+// environment. The caller remains responsible for closing w and encoder, if
+// they require closing.
+//
 // The resulting stream can be randomly accessed through Reader or NewSeekTable.
 func NewWriter(w io.Writer, encoder ZSTDEncoder, opts ...wOption) (ConcurrentWriter, error) {
 	sw := writerImpl{

--- a/pkg/writer_options.go
+++ b/pkg/writer_options.go
@@ -8,6 +8,8 @@ import (
 type wOption func(*writerImpl) error
 
 // WithWLogger sets the logger used by Writer and Encoder internals.
+//
+// Passing nil restores the default discard logger.
 func WithWLogger(l *slog.Logger) wOption {
 	if l == nil {
 		l = discardLogger
@@ -16,6 +18,9 @@ func WithWLogger(l *slog.Logger) wOption {
 }
 
 // WithWEnvironment sets a custom write environment for advanced storage implementations.
+//
+// When this option is supplied, NewWriter uses e instead of the io.Writer
+// argument for all frame and seek-table writes.
 func WithWEnvironment(e WEnvironment) wOption {
 	return func(w *writerImpl) error { w.env = e; return nil }
 }
@@ -25,9 +30,12 @@ type writeManyOptions struct {
 	writeCallback func(uint32)
 }
 
+// WriteManyOption configures ConcurrentWriter.WriteMany.
 type WriteManyOption func(options *writeManyOptions) error
 
 // WithConcurrency sets the maximum number of concurrent frame encoding operations.
+//
+// The default is runtime.GOMAXPROCS(0).
 func WithConcurrency(concurrency int) WriteManyOption {
 	return func(options *writeManyOptions) error {
 		if concurrency < 1 {
@@ -38,7 +46,10 @@ func WithConcurrency(concurrency int) WriteManyOption {
 	}
 }
 
-// WithWriteCallback calls cb after each frame is written, passing the decompressed frame size.
+// WithWriteCallback calls cb after each frame is written.
+//
+// cb receives the decompressed size of the frame that was just written. It is
+// called in stream order from the WriteMany writer goroutine.
 func WithWriteCallback(cb func(size uint32)) WriteManyOption {
 	return func(options *writeManyOptions) error {
 		options.writeCallback = cb


### PR DESCRIPTION
## Summary

- Expand the package overview with seekable-stream behavior, random access offsets, and encoder/decoder compatibility.
- Clarify public godoc for readers, writers, encoders, seek tables, environments, frame offsets, and WriteMany options.
- Split the broad package example into symbol-targeted examples for NewWriter, NewReader, NewSeekTable, and ConcurrentWriter.WriteMany.
- Check zstd encoder close errors in examples to satisfy `golangci-lint`.

## Notes

This intentionally leaves the public option type names unchanged for now, so constructor signatures still render with the existing unexported rOption/wOption types.

## Validation

- GitHub Actions: only `golangci-lint` failed on the previous head; root cause was unchecked `enc.Close()` in `pkg/example_test.go`.
- `env GOCACHE=/tmp/codex-go-build-cache go test ./...`
- `env GOCACHE=/tmp/codex-go-build-cache GOLANGCI_LINT_CACHE=/tmp/codex-golangci-lint-cache golangci-lint run`
- `env GOCACHE=/tmp/codex-go-build-cache go doc -all .`
- `git diff --check`