### PR TITLE
writer: stop after failed frame writes

### DIFF
--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -12,7 +12,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var errWriterClosed = errors.New("writer is closed")
+var (
+	errWriterClosed = errors.New("writer is closed")
+	errWriterFailed = errors.New("writer has failed")
+)
 
 // writerEnvImpl is the environment implementation of for the underlying WriteCloser.
 type writerEnvImpl struct {
@@ -33,6 +36,7 @@ type writerImpl struct {
 
 	logger *slog.Logger
 	env    WEnvironment
+	failed bool
 
 	mu sync.Mutex
 }
@@ -53,6 +57,11 @@ type Writer interface {
 	// Note that Write does not do any coalescing nor splitting of data,
 	// so each non-empty write will map to a separate Zstandard frame.
 	// Empty writes do not add seek-table entries.
+	//
+	// If the underlying frame write fails or writes only part of the frame, the
+	// writer stops accepting more frames. Close may still be called to write the
+	// seek table for frames that were fully written. Bytes already accepted by
+	// the underlying writer are not rolled back.
 	Write(src []byte) (int, error)
 
 	// Close implements io.Closer. It writes the seek table, releases the in-memory
@@ -77,7 +86,8 @@ type ConcurrentWriter interface {
 	// It reads frames from frameSource sequentially, compresses up to the
 	// configured concurrency in parallel, and writes compressed frames in the
 	// same order returned by frameSource. Close must still be called after a
-	// successful WriteMany call to write the final seek table.
+	// successful WriteMany call to write the final seek table. Frame write
+	// failures have the same no-more-frames behavior as Writer.Write.
 	WriteMany(ctx context.Context, frameSource FrameSource, options ...WriteManyOption) error
 }
 
@@ -125,20 +135,30 @@ func (s *writerImpl) Write(src []byte) (int, error) {
 	if s.env == nil {
 		return 0, errWriterClosed
 	}
+	if s.failed {
+		return 0, errWriterFailed
+	}
 
-	dst, err := s.Encode(src)
+	dst, entry, err := s.encodeOne(src)
 	if err != nil {
 		return 0, err
+	}
+	if len(src) == 0 {
+		return 0, nil
 	}
 
 	n, err := s.env.WriteFrame(dst)
 	if err != nil {
+		s.failed = true
 		return 0, err
 	}
 	if n != len(dst) {
+		s.failed = true
 		return 0, fmt.Errorf("partial write: %d out of %d", n, len(dst))
 	}
 
+	s.logger.Debug("appending frame", slog.Any("frame", &entry))
+	s.frameEntries = append(s.frameEntries, entry)
 	return len(src), nil
 }
 
@@ -233,9 +253,11 @@ func (s *writerImpl) writeManyConsumer(ctx context.Context, callback func(uint32
 
 			n, err := s.env.WriteFrame(result.buf)
 			if err != nil {
+				s.failed = true
 				return fmt.Errorf("failed to write compressed data: %w", err)
 			}
 			if n != len(result.buf) {
+				s.failed = true
 				return fmt.Errorf("partial write: %d out of %d", n, len(result.buf))
 			}
 			s.frameEntries = append(s.frameEntries, result.entry)
@@ -253,6 +275,9 @@ func (s *writerImpl) WriteMany(ctx context.Context, frameSource FrameSource, opt
 
 	if s.env == nil {
 		return errWriterClosed
+	}
+	if s.failed {
+		return errWriterFailed
 	}
 
 	opts := writeManyOptions{concurrency: runtime.GOMAXPROCS(0)}

--- a/pkg/writer_test.go
+++ b/pkg/writer_test.go
@@ -140,6 +140,23 @@ func (e failingWriteEnvironment) WriteSeekTable(p []byte) (n int, err error) {
 	return e.n, e.err
 }
 
+type partialSecondFrameEnvironment struct {
+	b           bytes.Buffer
+	frameWrites int
+}
+
+func (e *partialSecondFrameEnvironment) WriteFrame(p []byte) (n int, err error) {
+	e.frameWrites++
+	if e.frameWrites == 2 {
+		return e.b.Write(p[:1])
+	}
+	return e.b.Write(p)
+}
+
+func (e *partialSecondFrameEnvironment) WriteSeekTable(p []byte) (n int, err error) {
+	return e.b.Write(p)
+}
+
 func TestConcurrentWriterErrors(t *testing.T) {
 	t.Parallel()
 
@@ -168,15 +185,86 @@ func TestConcurrentWriterErrors(t *testing.T) {
 	w, err = NewWriter(&b, enc,
 		WithWEnvironment(failingWriteEnvironment{0, errors.New("test error")}))
 	require.NoError(t, err)
-	frameSource = makeTestFrameSource(manyFrames) // enough that we have to wait on ctx
-	err = w.WriteMany(ctx, frameSource, WithConcurrency(1))
+	err = w.WriteMany(ctx, makeTestFrameSource(manyFrames), WithConcurrency(1))
 	assert.ErrorContains(t, err, "failed to write compressed data")
+	_, err = w.Write([]byte("again"))
+	assert.ErrorIs(t, err, errWriterFailed)
 
 	w, err = NewWriter(&b, enc,
 		WithWEnvironment(failingWriteEnvironment{1, nil}))
 	require.NoError(t, err)
-	err = w.WriteMany(ctx, frameSource, WithConcurrency(1))
+	err = w.WriteMany(ctx, makeTestFrameSource(manyFrames), WithConcurrency(1))
 	assert.ErrorContains(t, err, "partial write")
+	_, err = w.Write([]byte("again"))
+	assert.ErrorIs(t, err, errWriterFailed)
+}
+
+func TestFrameWriteFailureAllowsClose(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		write func(t *testing.T, w ConcurrentWriter, frames [][]byte) error
+	}{
+		{
+			name: "Write",
+			write: func(t *testing.T, w ConcurrentWriter, frames [][]byte) error {
+				t.Helper()
+
+				_, err := w.Write(frames[0])
+				require.NoError(t, err)
+				_, err = w.Write(frames[1])
+				return err
+			},
+		},
+		{
+			name: "WriteMany",
+			write: func(t *testing.T, w ConcurrentWriter, frames [][]byte) error {
+				t.Helper()
+
+				return w.WriteMany(context.Background(), makeTestFrameSource(frames), WithConcurrency(1))
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
+			require.NoError(t, err)
+			dec, err := zstd.NewReader(nil)
+			require.NoError(t, err)
+			defer dec.Close()
+
+			env := &partialSecondFrameEnvironment{}
+			w, err := NewWriter(nil, enc, WithWEnvironment(env))
+			require.NoError(t, err)
+
+			frames := [][]byte{[]byte("first"), []byte("second")}
+			err = tc.write(t, w, frames)
+			require.ErrorContains(t, err, "partial write")
+
+			_, err = w.Write([]byte("again"))
+			assert.ErrorIs(t, err, errWriterFailed)
+
+			err = w.Close()
+			require.NoError(t, err)
+
+			table, err := readSeekTable(&readSeekerEnvImpl{rs: bytes.NewReader(env.b.Bytes())})
+			require.NoError(t, err)
+			assert.Equal(t, uint64(len(frames[0])), table.Size())
+			assert.Equal(t, int64(1), table.NumFrames())
+
+			r, err := NewReader(bytes.NewReader(env.b.Bytes()), dec)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, r.Close()) }()
+
+			got := make([]byte, len(frames[0]))
+			n, err := r.ReadAt(got, 0)
+			require.NoError(t, err)
+			assert.Equal(t, len(got), n)
+			assert.Equal(t, frames[0], got)
+		})
+	}
 }
 
 type fakeWriteEnvironment struct {


### PR DESCRIPTION
## Summary
- Make `Writer.Write` encode without mutating `frameEntries` first.
- Append frame metadata only after the compressed frame is fully written.
- After a frame write error or partial frame write, stop accepting more frames but keep the completed frame index.
- Allow `Close` after a frame write failure so it can write a seek table for frames that were fully written.
- Apply the same behavior to `WriteMany` frame writes.

## Notes
- This makes frame writes metadata-atomic: the seek table will not describe a frame that failed to write completely.
- A partially written failed frame may leave extra bytes in the underlying stream, but random access to completed frames remains possible if `Close` writes the seek table successfully.
- The underlying byte stream is not transactional; bytes already accepted by the underlying writer cannot be rolled back.

## Validation
- `env GOCACHE=/tmp/codex-go-build-cache go test ./...`
- `env GOCACHE=/tmp/codex-go-build-cache go test -race ./...`
- `env GOCACHE=/tmp/codex-go-build-cache GOLANGCI_LINT_CACHE=/tmp/codex-golangci-lint-cache golangci-lint run`
- `/tmp/codex-typos/bin/typos --format brief . .github`
- `git diff --check`