### PR TITLE
ci: harden workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     types: [opened, synchronize, closed]
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     name: coverage

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,8 @@ on:
   schedule:
     - cron: '40 8 * * 3'
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: ['*']
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,6 +5,10 @@ on:
     tags: ['v*']
   pull_request:
     branches: ['*']
+
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: ['*']
 
+permissions:
+  contents: read
+
 jobs:
   typos:
     name: typos


### PR DESCRIPTION
## Problem
Several workflows relied on GitHub's default `GITHUB_TOKEN` permissions, which leaves the effective token scope dependent on repository or organization settings and triggers token-permission warnings.

## Solution
Add explicit top-level read-only `contents` permissions to build, lint, coverage, and typo workflows. Set the CodeQL workflow default permissions to none while keeping its analyze job scoped to the permissions required for checkout and code-scanning upload.

## Validation
- `git diff --check`
- `python3 -c 'import sys, yaml; [yaml.safe_load(open(f, encoding="utf-8")) for f in sys.argv[1:]]; print("workflow yaml parsed")' .github/workflows/*.yml`