### PR TITLE
ci: publish OpenSSF Scorecard results

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,28 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 1 * * 6'
+
+permissions: {}
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-  [![License][license-img]][license] [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Go Report][report-img]][report]
+  [![License][license-img]][license] [![OpenSSF Scorecard][scorecard-img]][scorecard] [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Go Report][report-img]][report]
 # ZSTD seekable compression format implementation in Go
 [Seekable ZSTD compression format](https://github.com/facebook/zstd/blob/dev/contrib/seekable_format/zstd_seekable_compression_format.md) implemented in Golang.
 
@@ -106,3 +106,5 @@ if !bytes.Equal(all, []byte("Hello World!")) {
 [report]: https://goreportcard.com/report/github.com/SaveTheRbtz/zstd-seekable-format-go/pkg
 [license-img]: https://img.shields.io/badge/License-MIT-blue.svg
 [license]: https://opensource.org/licenses/MIT
+[scorecard-img]: https://api.scorecard.dev/projects/github.com/SaveTheRbtz/zstd-seekable-format-go/badge
+[scorecard]: https://scorecard.dev/viewer/?uri=github.com/SaveTheRbtz/zstd-seekable-format-go


### PR DESCRIPTION
## Problem
The project did not expose OpenSSF Scorecard results through the public Scorecard badge/API flow. The OpenSSF Scorecard README and badge announcement recommend enabling `publish_results: true` in the Scorecard action and adding the `api.scorecard.dev` badge to the README.

## Solution
- Add a pinned OpenSSF Scorecard workflow that runs on `main` pushes and weekly schedules.
- Enable `publish_results: true` so the Scorecard API and README badge can show the latest project score.
- Add the OpenSSF Scorecard badge to `README.md`.
- Keep workflow token permissions narrow: top-level permissions are disabled, and the Scorecard job only gets `contents: read` plus the `id-token: write` permission required for result publishing.

## Notes
This is the repo-side Scorecard badge setup from the OpenSSF Scorecard documentation. The separate `CII-Best-Practices` Scorecard check is backed by the OpenSSF Best Practices badge API, so getting full credit for that specific check still requires a maintainer to create or claim the project entry on bestpractices.dev.

## Validation
- `git diff --check`
- `python3 -c 'import sys, yaml; [yaml.safe_load(open(f, encoding="utf-8")) for f in sys.argv[1:]]; print("workflow yaml parsed")' .github/workflows/*.yml .github/dependabot.yml`
- `rg --pcre2 -n "uses: [^@]+@(?![0-9a-f]{40}(?:\\s+#|\\s*$))" .github/workflows` returned no matches