### PR TITLE
pkg: standardize lifecycle finalization

### DIFF
--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -12,6 +12,8 @@
 // Writer and Encoder produce seekable streams by storing each non-empty input
 // chunk as a separate Zstandard frame. Close or EndStream must be called to
 // append or retrieve the final seek-table skippable frame.
+// Close is idempotent; EndStream finalizes the Encoder and must be called once.
+// Operations after Close or EndStream return ErrClosed.
 //
 // The package accepts small encoder and decoder interfaces and is tested with
 // github.com/klauspost/compress/zstd.

--- a/pkg/encoder.go
+++ b/pkg/encoder.go
@@ -12,13 +12,15 @@ import (
 // Each non-empty Encode call returns one compressed Zstandard frame and appends
 // one entry to the in-memory seek table. EndStream returns the final seek-table
 // skippable frame, which must be appended after all encoded frames to form a
-// complete seekable stream.
+// complete seekable stream. EndStream finalizes the encoder. After EndStream,
+// Encode and EndStream return ErrClosed.
 type Encoder interface {
 	// Encode returns compressed data and appends a frame to in-memory seek table.
 	// Empty inputs return an empty slice and do not add seek-table entries.
 	Encode(src []byte) ([]byte, error)
 
-	// EndStream returns the in-memory seek table as a Zstandard skippable frame.
+	// EndStream returns the in-memory seek table as a Zstandard skippable frame
+	// and finalizes the encoder.
 	EndStream() ([]byte, error)
 }
 
@@ -61,6 +63,12 @@ func (s *writerImpl) encodeOne(src []byte) ([]byte, seekTableEntry, error) {
 }
 
 func (s *writerImpl) Encode(src []byte) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return nil, ErrClosed
+	}
 	if len(src) == 0 {
 		return []byte{}, nil
 	}
@@ -76,6 +84,17 @@ func (s *writerImpl) Encode(src []byte) ([]byte, error) {
 }
 
 func (s *writerImpl) EndStream() ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.endStreamLocked()
+}
+
+func (s *writerImpl) endStreamLocked() ([]byte, error) {
+	if s.closed {
+		return nil, ErrClosed
+	}
+
 	if int64(len(s.frameEntries)) > maxNumberOfFrames {
 		return nil, fmt.Errorf("number of frames for seekable format: %d > %d",
 			len(s.frameEntries), maxNumberOfFrames)
@@ -95,5 +114,12 @@ func (s *writerImpl) EndStream() ([]byte, error) {
 	}
 
 	footer.marshalBinaryInline(seekTable[len(s.frameEntries)*12 : len(s.frameEntries)*12+9])
-	return createSkippableFrame(seekableTag, seekTable)
+	frame, err := createSkippableFrame(seekableTag, seekTable)
+	if err != nil {
+		return nil, err
+	}
+
+	s.closed = true
+	s.frameEntries = nil
+	return frame, nil
 }

--- a/pkg/encoder_test.go
+++ b/pkg/encoder_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,4 +46,32 @@ func TestEncoder(t *testing.T) {
 
 	require.Equal(t, uint64(len(sourceString)), table.Size())
 	require.Equal(t, int64(len(chunks)), table.NumFrames())
+}
+
+func TestEncoderEndStreamFinalizes(t *testing.T) {
+	t.Parallel()
+
+	enc, err := zstd.NewWriter(nil)
+	require.NoError(t, err)
+
+	e, err := NewEncoder(enc)
+	require.NoError(t, err)
+	se := e.(*writerImpl)
+
+	_, err = e.Encode([]byte("foo"))
+	require.NoError(t, err)
+	require.NotEmpty(t, se.frameEntries)
+
+	footer, err := e.EndStream()
+	require.NoError(t, err)
+	require.NotEmpty(t, footer)
+	assert.Nil(t, se.frameEntries)
+
+	footer, err = e.EndStream()
+	assert.Nil(t, footer)
+	assert.ErrorIs(t, err, ErrClosed)
+
+	encoded, err := e.Encode([]byte("bar"))
+	assert.Nil(t, encoded)
+	assert.ErrorIs(t, err, ErrClosed)
 }

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -1,0 +1,7 @@
+package seekable
+
+import "errors"
+
+// ErrClosed is returned by operations after a Reader, Writer, or Encoder has
+// been closed or finalized.
+var ErrClosed = errors.New("seekable: closed")

--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -115,8 +115,6 @@ type readerImpl struct {
 	cachedFrame cachedFrame
 }
 
-var errReaderClosed = errors.New("reader is closed")
-
 var (
 	_ Reader      = (*readerImpl)(nil)
 	_ io.Seeker   = (*readerImpl)(nil)
@@ -135,6 +133,7 @@ type Reader interface {
 	io.Seeker
 
 	// Close releases reader-owned memory and causes future Reader method calls to fail.
+	// Close is idempotent. Read, ReadAt, and Seek return ErrClosed after Close.
 	Close() error
 }
 
@@ -191,7 +190,7 @@ func NewReader(rs io.ReadSeeker, decoder ZSTDDecoder, opts ...rOption) (Reader, 
 
 func (r *readerImpl) ReadAt(p []byte, off int64) (n int, err error) {
 	if r.closed.Load() {
-		return 0, errReaderClosed
+		return 0, ErrClosed
 	}
 
 	for m := 0; n < len(p) && err == nil; n += m {
@@ -222,7 +221,7 @@ func (r *readerImpl) Close() error {
 
 func (r *readerImpl) read(dst []byte, off int64) (int64, int, error) {
 	if r.closed.Load() {
-		return 0, 0, errReaderClosed
+		return 0, 0, ErrClosed
 	}
 
 	if off < 0 {
@@ -299,7 +298,7 @@ func (r *readerImpl) read(dst []byte, off int64) (int64, int, error) {
 
 func (r *readerImpl) Seek(offset int64, whence int) (int64, error) {
 	if r.closed.Load() {
-		return 0, errReaderClosed
+		return 0, ErrClosed
 	}
 
 	newOffset := r.offset

--- a/pkg/reader_test.go
+++ b/pkg/reader_test.go
@@ -219,7 +219,7 @@ func TestReaderPostCloseContract(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			require.ErrorIs(t, tc.call(), errReaderClosed)
+			require.ErrorIs(t, tc.call(), ErrClosed)
 		})
 	}
 }

--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -13,7 +13,6 @@ import (
 )
 
 var (
-	errWriterClosed = errors.New("writer is closed")
 	errWriterFailed = errors.New("writer has failed")
 )
 
@@ -37,6 +36,7 @@ type writerImpl struct {
 	logger *slog.Logger
 	env    WEnvironment
 	failed bool
+	closed bool
 
 	mu sync.Mutex
 }
@@ -51,6 +51,7 @@ var (
 // Each non-empty Write call becomes one Zstandard frame in the output stream.
 // Close must be called to write the final seek-table skippable frame; without
 // it, Reader and NewSeekTable cannot find the random-access metadata.
+// Close is idempotent. Write and WriteMany return ErrClosed after Close.
 type Writer interface {
 	// Write writes a chunk of data as a separate frame into the data stream.
 	//
@@ -132,8 +133,8 @@ func (s *writerImpl) Write(src []byte) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.env == nil {
-		return 0, errWriterClosed
+	if s.env == nil || s.closed {
+		return 0, ErrClosed
 	}
 	if s.failed {
 		return 0, errWriterFailed
@@ -167,10 +168,10 @@ func (s *writerImpl) Close() error {
 	defer s.mu.Unlock()
 
 	if s.env == nil {
-		return errWriterClosed
+		return nil
 	}
 
-	err := s.writeSeekTable()
+	err := s.writeSeekTableLocked()
 	s.frameEntries = nil
 	s.env = nil
 	return err
@@ -273,8 +274,8 @@ func (s *writerImpl) WriteMany(ctx context.Context, frameSource FrameSource, opt
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.env == nil {
-		return errWriterClosed
+	if s.env == nil || s.closed {
+		return ErrClosed
 	}
 	if s.failed {
 		return errWriterFailed
@@ -299,8 +300,8 @@ func (s *writerImpl) WriteMany(ctx context.Context, frameSource FrameSource, opt
 	return g.Wait()
 }
 
-func (s *writerImpl) writeSeekTable() error {
-	seekTableBytes, err := s.EndStream()
+func (s *writerImpl) writeSeekTableLocked() error {
+	seekTableBytes, err := s.endStreamLocked()
 	if err != nil {
 		return err
 	}

--- a/pkg/writer_test.go
+++ b/pkg/writer_test.go
@@ -428,18 +428,20 @@ func TestWriterCloseSemantics(t *testing.T) {
 
 	require.NoError(t, w.Close())
 	assert.Nil(t, sw.frameEntries)
+	sizeAfterClose := b.Len()
 
-	// double close should return an error
+	// double close should be a no-op
 	err = w.Close()
-	assert.ErrorIs(t, err, errWriterClosed)
+	assert.NoError(t, err)
+	assert.Equal(t, sizeAfterClose, b.Len())
 
 	// write after close should return an error
 	_, err = w.Write([]byte("bar"))
-	assert.ErrorIs(t, err, errWriterClosed)
+	assert.ErrorIs(t, err, ErrClosed)
 
 	// write many after close should return an error
 	err = w.WriteMany(context.Background(), makeTestFrameSource([][]byte{[]byte("baz")}))
-	assert.ErrorIs(t, err, errWriterClosed)
+	assert.ErrorIs(t, err, ErrClosed)
 }
 
 func makeRepeatingFrameSource(frame []byte, count int) FrameSource {


### PR DESCRIPTION
## Summary
- Add exported `ErrClosed` for operations after reader, writer, and encoder finalization.
- Make `Writer.Close` idempotent while keeping `Write` and `WriteMany` closed after finalization.
- Make `Encoder.EndStream` terminal and release its in-memory seek table after emitting the final frame.
- Update reader, writer, encoder docs and tests for the shared lifecycle contract.

## Validation
- `go test ./...`
- `go vet ./...`
- `git diff --check HEAD^ HEAD`