### PR TITLE
pkg: validate constructor inputs

### DIFF
--- a/pkg/encoder.go
+++ b/pkg/encoder.go
@@ -26,14 +26,10 @@ type Encoder interface {
 
 // NewEncoder returns a byte-oriented encoder that uses encoder for Zstandard compression.
 //
-// The caller remains responsible for closing encoder, if it requires closing.
+// encoder must be non-nil. The caller remains responsible for closing encoder,
+// if it requires closing.
 func NewEncoder(encoder ZSTDEncoder, opts ...wOption) (Encoder, error) {
-	sw, err := NewWriter(nil, encoder, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	return sw.(*writerImpl), err
+	return newWriterImpl(encoder, opts...)
 }
 
 func (s *writerImpl) encodeOne(src []byte) ([]byte, seekTableEntry, error) {

--- a/pkg/encoder_test.go
+++ b/pkg/encoder_test.go
@@ -75,3 +75,11 @@ func TestEncoderEndStreamFinalizes(t *testing.T) {
 	assert.Nil(t, encoded)
 	assert.ErrorIs(t, err, ErrClosed)
 }
+
+func TestNewEncoderRejectsNilEncoder(t *testing.T) {
+	t.Parallel()
+
+	e, err := NewEncoder(nil)
+	assert.Nil(t, e)
+	assert.ErrorContains(t, err, "nil encoder")
+}

--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -150,10 +150,15 @@ type ZSTDDecoder interface {
 // The stream must contain a final seek-table skippable frame. rs must be
 // non-nil unless WithREnvironment supplies a custom read environment. If rs
 // also implements io.ReaderAt, frame reads do not move rs's current offset.
+// decoder must be non-nil.
 //
 // NewReader reads and validates the seek table during construction. The caller
 // remains responsible for closing rs and decoder, if they require closing.
 func NewReader(rs io.ReadSeeker, decoder ZSTDDecoder, opts ...rOption) (Reader, error) {
+	if decoder == nil {
+		return nil, fmt.Errorf("nil decoder")
+	}
+
 	sr := readerImpl{
 		dec: decoder,
 	}

--- a/pkg/reader_test.go
+++ b/pkg/reader_test.go
@@ -628,7 +628,7 @@ func TestEmptyWriteRead(t *testing.T) {
 	assert.Equal(t, 0, n)
 }
 
-func TestNilReaderNoEnvironment(t *testing.T) {
+func TestNewReaderRejectsNilInputs(t *testing.T) {
 	t.Parallel()
 
 	dec, err := zstd.NewReader(nil)
@@ -638,4 +638,13 @@ func TestNilReaderNoEnvironment(t *testing.T) {
 	r, err := NewReader(nil, dec)
 	require.Error(t, err)
 	assert.Nil(t, r)
+	assert.ErrorContains(t, err, "nil ReadSeeker")
+
+	r, err = NewReader(&seekableBufferReaderAt{buf: checksum}, nil)
+	assert.Nil(t, r)
+	assert.ErrorContains(t, err, "nil decoder")
+
+	r, err = NewReader(nil, dec, WithREnvironment(&fakeReadEnvironment{}))
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
 }

--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -103,11 +103,33 @@ type ZSTDEncoder interface {
 // NewWriter wraps w and encoder into an indexed Zstandard stream.
 //
 // w must be non-nil unless WithWEnvironment supplies a custom write
-// environment. The caller remains responsible for closing w and encoder, if
-// they require closing.
+// environment. encoder must be non-nil. The caller remains responsible for
+// closing w and encoder, if they require closing.
 //
 // The resulting stream can be randomly accessed through Reader or NewSeekTable.
 func NewWriter(w io.Writer, encoder ZSTDEncoder, opts ...wOption) (ConcurrentWriter, error) {
+	sw, err := newWriterImpl(encoder, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	if sw.env == nil {
+		if w == nil {
+			return nil, fmt.Errorf("nil Writer and no custom environment supplied")
+		}
+		sw.env = &writerEnvImpl{
+			w: w,
+		}
+	}
+
+	return sw, nil
+}
+
+func newWriterImpl(encoder ZSTDEncoder, opts ...wOption) (*writerImpl, error) {
+	if encoder == nil {
+		return nil, fmt.Errorf("nil encoder")
+	}
+
 	sw := writerImpl{
 		enc: encoder,
 	}
@@ -117,12 +139,6 @@ func NewWriter(w io.Writer, encoder ZSTDEncoder, opts ...wOption) (ConcurrentWri
 		err := o(&sw)
 		if err != nil {
 			return nil, err
-		}
-	}
-
-	if sw.env == nil {
-		sw.env = &writerEnvImpl{
-			w: w,
 		}
 	}
 

--- a/pkg/writer_test.go
+++ b/pkg/writer_test.go
@@ -51,6 +51,25 @@ func TestWriter(t *testing.T) {
 	assert.Equal(t, concat, readBuf[:n])
 }
 
+func TestNewWriterRejectsNilInputs(t *testing.T) {
+	t.Parallel()
+
+	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
+	require.NoError(t, err)
+
+	w, err := NewWriter(nil, enc)
+	assert.Nil(t, w)
+	assert.ErrorContains(t, err, "nil Writer")
+
+	w, err = NewWriter(io.Discard, nil)
+	assert.Nil(t, w)
+	assert.ErrorContains(t, err, "nil encoder")
+
+	w, err = NewWriter(nil, enc, WithWEnvironment(&fakeWriteEnvironment{bw: io.Discard}))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+}
+
 func makeTestFrame(t *testing.T, idx int) []byte {
 	var b bytes.Buffer
 	for i := 0; i < 100; i++ {
@@ -168,7 +187,7 @@ func TestConcurrentWriterErrors(t *testing.T) {
 	ctx := context.Background()
 	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
 	require.NoError(t, err)
-	w, err := NewWriter(nil, enc)
+	w, err := NewWriter(io.Discard, enc)
 	require.NoError(t, err)
 
 	frameSource := makeTestFrameSource([][]byte{})


### PR DESCRIPTION
## Summary
- Reject nil encoders in `NewWriter` and `NewEncoder` before any encode path can panic.
- Reject nil decoders in `NewReader` before reading the seek table.
- Enforce the documented nil writer rule in `NewWriter`, while preserving the custom environment path.
- Add focused constructor tests for nil inputs and custom environment exceptions.

## Validation
- `go test ./...`
- `go vet ./...`
- `git diff --check`