### PR TITLE
cmd: bump package dependency

### DIFF
--- a/cmd/zstdseek/go.mod
+++ b/cmd/zstdseek/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/SaveTheRbtz/fastcdc-go v0.3.0
-	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.0
+	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.1-0.20260602065614-d67e900dbcf7
 	github.com/klauspost/compress v1.18.6
 	github.com/schollz/progressbar/v3 v3.19.0
 	go.uber.org/zap v1.28.0
@@ -14,7 +14,6 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/google/btree v1.1.3 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/cmd/zstdseek/go.sum
+++ b/cmd/zstdseek/go.sum
@@ -1,15 +1,13 @@
 github.com/SaveTheRbtz/fastcdc-go v0.3.0 h1:JdHvLlnijDuisYIwpRDcHZEjbxvCqtEmJ3gf35VJBgA=
 github.com/SaveTheRbtz/fastcdc-go v0.3.0/go.mod h1:2kMKqvBv1h9wCaUfETqsVkSESsCiFhp4YyEHyz7/SfE=
-github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.0 h1:Ll4yOKpGMvvA/TjNrDp4bDvi7nW8iRy8xFpNy1O23Ys=
-github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.0/go.mod h1:Lu5IBw6UTH8a4tmV8htv390pZikb21ZoNvcM0Y1aQho=
+github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.1-0.20260602065614-d67e900dbcf7 h1:v+SGGXz/XSqTUG+ywKQxDwqNhB7xhJ8juQYVy8ALfPQ=
+github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.1-0.20260602065614-d67e900dbcf7/go.mod h1:I28hc9eaiqKCoOB+9Wh/P1IOScfm0xCgyWC6DAo0lmo=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chengxilo/virtualterm v1.0.4 h1:Z6IpERbRVlfB8WkOmtbHiDbBANU7cimRIof7mk9/PwM=
 github.com/chengxilo/virtualterm v1.0.4/go.mod h1:DyxxBZz/x1iqJjFxTFcr6/x+jSpqN0iwWCOK1q10rlY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
-github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=

--- a/cmd/zstdseek/main.go
+++ b/cmd/zstdseek/main.go
@@ -144,7 +144,7 @@ func main() {
 		logger.Fatal("failed to create zstd encoder", zap.Error(err))
 	}
 
-	w, err := seekable.NewWriter(output, enc, seekable.WithWLogger(seekableLogger.WithGroup("writer")))
+	w, err := seekable.NewWriter(output, enc, seekable.WithWriterLogger(seekableLogger.WithGroup("writer")))
 	if err != nil {
 		logger.Fatal("failed to create compressed writer", zap.Error(err))
 	}
@@ -202,7 +202,7 @@ func main() {
 		}
 		defer dec.Close()
 
-		reader, err := seekable.NewReader(verify, dec, seekable.WithRLogger(seekableLogger.WithGroup("reader")))
+		reader, err := seekable.NewReader(verify, dec, seekable.WithReaderLogger(seekableLogger.WithGroup("reader")))
 		if err != nil {
 			logger.Fatal("failed to create new seekable reader", zap.Error(err))
 		}


### PR DESCRIPTION
## What Changed

- Bumped `cmd/zstdseek` from `github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.0` to the current `main` pseudo-version `v0.9.1-0.20260602065614-d67e900dbcf7`.
- Updated command call sites for the renamed logger options:
  - `WithWLogger` -> `WithWriterLogger`
  - `WithRLogger` -> `WithReaderLogger`
- Ran `go mod tidy`, which removed stale indirect `google/btree` entries from the command module.

## Why

The package API rename has landed on `main`, so the command module can now move to that package version and use the new public option names.

## Validation

- `go test ./...` in `cmd/zstdseek`
- `go list -m github.com/SaveTheRbtz/zstd-seekable-format-go/pkg` in `cmd/zstdseek`
- `git diff --check`