### PR TITLE
cmd: replace zap with slog

### DIFF
--- a/cmd/zstdseek/go.mod
+++ b/cmd/zstdseek/go.mod
@@ -7,8 +7,6 @@ require (
 	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.1-0.20260602065614-d67e900dbcf7
 	github.com/klauspost/compress v1.18.6
 	github.com/schollz/progressbar/v3 v3.19.0
-	go.uber.org/zap v1.28.0
-	go.uber.org/zap/exp v0.3.0
 	golang.org/x/term v0.43.0
 )
 
@@ -16,7 +14,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 )

--- a/cmd/zstdseek/go.sum
+++ b/cmd/zstdseek/go.sum
@@ -22,16 +22,6 @@ github.com/schollz/progressbar/v3 v3.19.0 h1:Ea18xuIRQXLAUidVDox3AbwfUhD0/1Ivohy
 github.com/schollz/progressbar/v3 v3.19.0/go.mod h1:IsO3lpbaGuzh8zIMzgY3+J8l4C8GjO0Y9S69eFvNsec=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
-go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
-go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
-go.uber.org/zap v1.28.0 h1:IZzaP1Fv73/T/pBMLk4VutPl36uNC+OSUh3JLG3FIjo=
-go.uber.org/zap v1.28.0/go.mod h1:rDLpOi171uODNm/mxFcuYWxDsqWSAVkFdX4XojSKg/Q=
-go.uber.org/zap/exp v0.3.0 h1:6JYzdifzYkGmTdRR59oYH+Ng7k49H9qVpWwNSsGJj3U=
-go.uber.org/zap/exp v0.3.0/go.mod h1:5I384qq7XGxYyByIhHm6jg5CHkGY0nsTfbDLgDDlgJQ=
-go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
-go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=

--- a/cmd/zstdseek/main.go
+++ b/cmd/zstdseek/main.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"flag"
 	"io"
-	"log"
 	"log/slog"
 	"os"
 	"strconv"
@@ -16,8 +15,6 @@ import (
 	"github.com/SaveTheRbtz/fastcdc-go"
 	"github.com/klauspost/compress/zstd"
 	"github.com/schollz/progressbar/v3"
-	"go.uber.org/zap"
-	"go.uber.org/zap/exp/zapslog"
 	"golang.org/x/term"
 
 	seekable "github.com/SaveTheRbtz/zstd-seekable-format-go/pkg"
@@ -26,6 +23,24 @@ import (
 type readCloser struct {
 	io.Reader
 	io.Closer
+}
+
+func newLogger(verbose bool) *slog.Logger {
+	level := slog.LevelInfo
+	if verbose {
+		level = slog.LevelDebug
+	}
+
+	opts := &slog.HandlerOptions{Level: level}
+	if verbose {
+		return slog.New(slog.NewTextHandler(os.Stderr, opts))
+	}
+	return slog.New(slog.NewJSONHandler(os.Stderr, opts))
+}
+
+func fatal(ctx context.Context, logger *slog.Logger, msg string, attrs ...slog.Attr) {
+	logger.LogAttrs(ctx, slog.LevelError, msg, attrs...)
+	os.Exit(1)
 }
 
 func main() {
@@ -47,27 +62,14 @@ func main() {
 	flag.Parse()
 
 	var err error
-	var logger *zap.Logger
-	if verboseFlag {
-		logger, err = zap.NewDevelopment()
-	} else {
-		logger, err = zap.NewProduction()
-	}
-	if err != nil {
-		log.Fatal("failed to initialize logger", err)
-	}
-	defer func() {
-		_ = logger.Sync()
-	}()
-
-	slogLogger := slog.New(zapslog.NewHandler(logger.Core(), zapslog.AddStacktraceAt(slog.Level(1000))))
-	seekableLogger := slogLogger.WithGroup("seekable")
+	logger := newLogger(verboseFlag)
+	seekableLogger := logger.WithGroup("seekable")
 
 	if inputFlag == "" || outputFlag == "" {
-		logger.Fatal("both input and output files need to be defined")
+		fatal(ctx, logger, "both input and output files need to be defined")
 	}
 	if verifyFlag && outputFlag == "-" {
-		logger.Fatal("verify can't be used with stdout output")
+		fatal(ctx, logger, "verify can't be used with stdout output")
 	}
 
 	bar := progressbar.DefaultSilent(0, "")
@@ -75,7 +77,7 @@ func main() {
 	inputFile := os.Stdin
 	if inputFlag != "-" {
 		if inputFile, err = os.Open(inputFlag); err != nil {
-			logger.Fatal("failed to open input", zap.Error(err))
+			fatal(ctx, logger, "failed to open input", slog.Any("error", err))
 		}
 
 		if term.IsTerminal(int(os.Stdout.Fd())) {
@@ -107,7 +109,7 @@ func main() {
 
 			m, err := io.CopyBuffer(expected, pr, make([]byte, 128<<10))
 			if err != nil {
-				logger.Fatal("failed to compute expected csum", zap.Int64("processed", m), zap.Error(err))
+				fatal(ctx, logger, "failed to compute expected csum", slog.Int64("processed", m), slog.Any("error", err))
 			}
 		}()
 	}
@@ -116,19 +118,19 @@ func main() {
 	if outputFlag != "-" {
 		output, err = os.OpenFile(outputFlag, os.O_TRUNC|os.O_WRONLY|os.O_CREATE, 0o644)
 		if err != nil {
-			logger.Fatal("failed to open output", zap.Error(err))
+			fatal(ctx, logger, "failed to open output", slog.Any("error", err))
 		}
 		defer output.Close()
 	}
 
 	chunkParams := strings.Split(chunkingFlag, ":")
 	if len(chunkParams) != 3 {
-		logger.Fatal("failed parse chunker params. len() != 3", zap.Int("actual", len(chunkParams)))
+		fatal(ctx, logger, "failed parse chunker params. len() != 3", slog.Int("actual", len(chunkParams)))
 	}
 	mustConv := func(s string) int {
 		n, err := strconv.Atoi(s)
 		if err != nil {
-			logger.Fatal("failed to parse int", zap.String("string", s), zap.Error(err))
+			fatal(ctx, logger, "failed to parse int", slog.String("string", s), slog.Any("error", err))
 		}
 		return n
 	}
@@ -141,17 +143,17 @@ func main() {
 	}
 	enc, err := zstd.NewWriter(nil, zstdOpts...)
 	if err != nil {
-		logger.Fatal("failed to create zstd encoder", zap.Error(err))
+		fatal(ctx, logger, "failed to create zstd encoder", slog.Any("error", err))
 	}
 
 	w, err := seekable.NewWriter(output, enc, seekable.WithWriterLogger(seekableLogger.WithGroup("writer")))
 	if err != nil {
-		logger.Fatal("failed to create compressed writer", zap.Error(err))
+		fatal(ctx, logger, "failed to create compressed writer", slog.Any("error", err))
 	}
 	defer w.Close()
 
 	// convert average chunk size to a number of bits
-	logger.Debug("setting chunker params", zap.Int("min", minChunkSize), zap.Int("max", maxChunkSize))
+	logger.Debug("setting chunker params", slog.Int("min", minChunkSize), slog.Int("max", maxChunkSize))
 	chunker, err := fastcdc.NewChunker(
 		input,
 		fastcdc.Options{
@@ -161,7 +163,7 @@ func main() {
 		},
 	)
 	if err != nil {
-		logger.Fatal("failed to create chunker", zap.Error(err))
+		fatal(ctx, logger, "failed to create chunker", slog.Any("error", err))
 	}
 
 	frameSource := func() ([]byte, error) {
@@ -180,7 +182,7 @@ func main() {
 		_ = bar.Add(int(size))
 	}))
 	if err != nil {
-		logger.Fatal("failed to write data", zap.Error(err))
+		fatal(ctx, logger, "failed to write data", slog.Any("error", err))
 	}
 
 	_ = bar.Finish()
@@ -192,33 +194,33 @@ func main() {
 
 		verify, err := os.Open(outputFlag)
 		if err != nil {
-			logger.Fatal("failed to open file for verification", zap.Error(err))
+			fatal(ctx, logger, "failed to open file for verification", slog.Any("error", err))
 		}
 		defer verify.Close()
 
 		dec, err := zstd.NewReader(nil)
 		if err != nil {
-			logger.Fatal("failed to create zstd decompressor", zap.Error(err))
+			fatal(ctx, logger, "failed to create zstd decompressor", slog.Any("error", err))
 		}
 		defer dec.Close()
 
 		reader, err := seekable.NewReader(verify, dec, seekable.WithReaderLogger(seekableLogger.WithGroup("reader")))
 		if err != nil {
-			logger.Fatal("failed to create new seekable reader", zap.Error(err))
+			fatal(ctx, logger, "failed to create new seekable reader", slog.Any("error", err))
 		}
 
 		actual := sha512.New512_256()
 		m, err := io.CopyBuffer(actual, reader, make([]byte, 128<<10))
 		if err != nil {
-			logger.Fatal("failed to compute actual csum", zap.Int64("processed", m), zap.Error(err))
+			fatal(ctx, logger, "failed to compute actual csum", slog.Int64("processed", m), slog.Any("error", err))
 		}
 		<-origDone
 
 		if !bytes.Equal(actual.Sum(nil), expected.Sum(nil)) {
-			logger.Fatal("checksum verification failed",
-				zap.Binary("actual", actual.Sum(nil)), zap.Binary("expected", expected.Sum(nil)))
+			fatal(ctx, logger, "checksum verification failed",
+				slog.Any("actual", actual.Sum(nil)), slog.Any("expected", expected.Sum(nil)))
 		} else {
-			logger.Info("checksum verification succeeded", zap.Binary("actual", actual.Sum(nil)))
+			logger.Info("checksum verification succeeded", slog.Any("actual", actual.Sum(nil)))
 		}
 	}
 }

--- a/cmd/zstdseek/main.go
+++ b/cmd/zstdseek/main.go
@@ -38,11 +38,6 @@ func newLogger(verbose bool) *slog.Logger {
 	return slog.New(slog.NewJSONHandler(os.Stderr, opts))
 }
 
-func fatal(ctx context.Context, logger *slog.Logger, msg string, attrs ...slog.Attr) {
-	logger.LogAttrs(ctx, slog.LevelError, msg, attrs...)
-	os.Exit(1)
-}
-
 func main() {
 	ctx := context.Background()
 
@@ -63,13 +58,17 @@ func main() {
 
 	var err error
 	logger := newLogger(verboseFlag)
+	fatal := func(msg string, attrs ...slog.Attr) {
+		logger.LogAttrs(ctx, slog.LevelError, msg, attrs...)
+		os.Exit(1)
+	}
 	seekableLogger := logger.WithGroup("seekable")
 
 	if inputFlag == "" || outputFlag == "" {
-		fatal(ctx, logger, "both input and output files need to be defined")
+		fatal("both input and output files need to be defined")
 	}
 	if verifyFlag && outputFlag == "-" {
-		fatal(ctx, logger, "verify can't be used with stdout output")
+		fatal("verify can't be used with stdout output")
 	}
 
 	bar := progressbar.DefaultSilent(0, "")
@@ -77,7 +76,7 @@ func main() {
 	inputFile := os.Stdin
 	if inputFlag != "-" {
 		if inputFile, err = os.Open(inputFlag); err != nil {
-			fatal(ctx, logger, "failed to open input", slog.Any("error", err))
+			fatal("failed to open input", slog.Any("error", err))
 		}
 
 		if term.IsTerminal(int(os.Stdout.Fd())) {
@@ -109,7 +108,7 @@ func main() {
 
 			m, err := io.CopyBuffer(expected, pr, make([]byte, 128<<10))
 			if err != nil {
-				fatal(ctx, logger, "failed to compute expected csum", slog.Int64("processed", m), slog.Any("error", err))
+				fatal("failed to compute expected csum", slog.Int64("processed", m), slog.Any("error", err))
 			}
 		}()
 	}
@@ -118,19 +117,19 @@ func main() {
 	if outputFlag != "-" {
 		output, err = os.OpenFile(outputFlag, os.O_TRUNC|os.O_WRONLY|os.O_CREATE, 0o644)
 		if err != nil {
-			fatal(ctx, logger, "failed to open output", slog.Any("error", err))
+			fatal("failed to open output", slog.Any("error", err))
 		}
 		defer output.Close()
 	}
 
 	chunkParams := strings.Split(chunkingFlag, ":")
 	if len(chunkParams) != 3 {
-		fatal(ctx, logger, "failed parse chunker params. len() != 3", slog.Int("actual", len(chunkParams)))
+		fatal("failed parse chunker params. len() != 3", slog.Int("actual", len(chunkParams)))
 	}
 	mustConv := func(s string) int {
 		n, err := strconv.Atoi(s)
 		if err != nil {
-			fatal(ctx, logger, "failed to parse int", slog.String("string", s), slog.Any("error", err))
+			fatal("failed to parse int", slog.String("string", s), slog.Any("error", err))
 		}
 		return n
 	}
@@ -143,12 +142,12 @@ func main() {
 	}
 	enc, err := zstd.NewWriter(nil, zstdOpts...)
 	if err != nil {
-		fatal(ctx, logger, "failed to create zstd encoder", slog.Any("error", err))
+		fatal("failed to create zstd encoder", slog.Any("error", err))
 	}
 
 	w, err := seekable.NewWriter(output, enc, seekable.WithWriterLogger(seekableLogger.WithGroup("writer")))
 	if err != nil {
-		fatal(ctx, logger, "failed to create compressed writer", slog.Any("error", err))
+		fatal("failed to create compressed writer", slog.Any("error", err))
 	}
 	defer w.Close()
 
@@ -163,7 +162,7 @@ func main() {
 		},
 	)
 	if err != nil {
-		fatal(ctx, logger, "failed to create chunker", slog.Any("error", err))
+		fatal("failed to create chunker", slog.Any("error", err))
 	}
 
 	frameSource := func() ([]byte, error) {
@@ -182,7 +181,7 @@ func main() {
 		_ = bar.Add(int(size))
 	}))
 	if err != nil {
-		fatal(ctx, logger, "failed to write data", slog.Any("error", err))
+		fatal("failed to write data", slog.Any("error", err))
 	}
 
 	_ = bar.Finish()
@@ -194,30 +193,30 @@ func main() {
 
 		verify, err := os.Open(outputFlag)
 		if err != nil {
-			fatal(ctx, logger, "failed to open file for verification", slog.Any("error", err))
+			fatal("failed to open file for verification", slog.Any("error", err))
 		}
 		defer verify.Close()
 
 		dec, err := zstd.NewReader(nil)
 		if err != nil {
-			fatal(ctx, logger, "failed to create zstd decompressor", slog.Any("error", err))
+			fatal("failed to create zstd decompressor", slog.Any("error", err))
 		}
 		defer dec.Close()
 
 		reader, err := seekable.NewReader(verify, dec, seekable.WithReaderLogger(seekableLogger.WithGroup("reader")))
 		if err != nil {
-			fatal(ctx, logger, "failed to create new seekable reader", slog.Any("error", err))
+			fatal("failed to create new seekable reader", slog.Any("error", err))
 		}
 
 		actual := sha512.New512_256()
 		m, err := io.CopyBuffer(actual, reader, make([]byte, 128<<10))
 		if err != nil {
-			fatal(ctx, logger, "failed to compute actual csum", slog.Int64("processed", m), slog.Any("error", err))
+			fatal("failed to compute actual csum", slog.Int64("processed", m), slog.Any("error", err))
 		}
 		<-origDone
 
 		if !bytes.Equal(actual.Sum(nil), expected.Sum(nil)) {
-			fatal(ctx, logger, "checksum verification failed",
+			fatal("checksum verification failed",
 				slog.Any("actual", actual.Sum(nil)), slog.Any("expected", expected.Sum(nil)))
 		} else {
 			logger.Info("checksum verification succeeded", slog.Any("actual", actual.Sum(nil)))


### PR DESCRIPTION
## Summary
- Replace `cmd/zstdseek` zap setup with stdlib `log/slog` handlers.
- Preserve normal JSON logging and verbose debug logging for the CLI.
- Run `go mod tidy` for the command module, removing zap, zapslog, and stale indirect entries from the dependency graph.

## Validation
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go mod tidy` in `cmd/zstdseek`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go test ./...` in `cmd/zstdseek`
- `git diff --check`
- `rg -n "go.uber.org|zap|zapslog" cmd/zstdseek` returned no matches