### PR TITLE
pkg: return concrete types

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library provides a random access reader (using uncompressed file offsets) f
 
 ## Using the seekable format
 
-Writing is done through the `Writer` interface:
+Writing is done through the `Writer` type:
 ```go
 import (
 	"github.com/klauspost/compress/zstd"

--- a/pkg/encoder.go
+++ b/pkg/encoder.go
@@ -14,29 +14,29 @@ import (
 // skippable frame, which must be appended after all encoded frames to form a
 // complete seekable stream. EndStream finalizes the encoder. After EndStream,
 // Encode and EndStream return ErrClosed.
-type Encoder interface {
-	// Encode returns compressed data and appends a frame to in-memory seek table.
-	// Empty inputs return an empty slice and do not add seek-table entries.
-	Encode(src []byte) ([]byte, error)
-
-	// EndStream returns the in-memory seek table as a Zstandard skippable frame
-	// and finalizes the encoder.
-	EndStream() ([]byte, error)
+type Encoder struct {
+	writer *Writer
 }
 
 // NewEncoder returns a byte-oriented encoder that uses encoder for Zstandard compression.
 //
 // The caller remains responsible for closing encoder, if it requires closing.
-func NewEncoder(encoder ZSTDEncoder, opts ...WriterOption) (Encoder, error) {
-	sw, err := NewWriter(nil, encoder, opts...)
-	if err != nil {
-		return nil, err
+func NewEncoder(encoder ZSTDEncoder, opts ...WriterOption) (*Encoder, error) {
+	writer := Writer{
+		enc:    encoder,
+		logger: discardLogger,
+	}
+	for _, o := range opts {
+		err := o(&writer)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return sw.(*writerImpl), err
+	return &Encoder{writer: &writer}, nil
 }
 
-func (s *writerImpl) encodeOne(src []byte) ([]byte, seekTableEntry, error) {
+func (w *Writer) encodeOne(src []byte) ([]byte, seekTableEntry, error) {
 	if int64(len(src)) > maxChunkSize {
 		return nil, seekTableEntry{},
 			fmt.Errorf("chunk size too big for seekable format: %d > %d",
@@ -47,7 +47,7 @@ func (s *writerImpl) encodeOne(src []byte) ([]byte, seekTableEntry, error) {
 		return nil, seekTableEntry{}, nil
 	}
 
-	dst := s.enc.EncodeAll(src, nil)
+	dst := w.enc.EncodeAll(src, nil)
 
 	if int64(len(dst)) > maxChunkSize {
 		return nil, seekTableEntry{},
@@ -62,35 +62,41 @@ func (s *writerImpl) encodeOne(src []byte) ([]byte, seekTableEntry, error) {
 	}, nil
 }
 
-func (s *writerImpl) Encode(src []byte) ([]byte, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+// Encode returns compressed data and appends a frame to the in-memory seek table.
+// Empty inputs return an empty slice and do not add seek-table entries.
+func (e *Encoder) Encode(src []byte) ([]byte, error) {
+	w := e.writer
+	w.mu.Lock()
+	defer w.mu.Unlock()
 
-	if s.closed {
+	if w.closed {
 		return nil, ErrClosed
 	}
 	if len(src) == 0 {
 		return []byte{}, nil
 	}
 
-	dst, entry, err := s.encodeOne(src)
+	dst, entry, err := w.encodeOne(src)
 	if err != nil {
 		return nil, err
 	}
 
-	s.logger.Debug("appending frame", slog.Any("frame", &entry))
-	s.frameEntries = append(s.frameEntries, entry)
+	w.logger.Debug("appending frame", slog.Any("frame", &entry))
+	w.frameEntries = append(w.frameEntries, entry)
 	return dst, nil
 }
 
-func (s *writerImpl) EndStream() ([]byte, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+// EndStream returns the in-memory seek table as a Zstandard skippable frame
+// and finalizes the encoder.
+func (e *Encoder) EndStream() ([]byte, error) {
+	w := e.writer
+	w.mu.Lock()
+	defer w.mu.Unlock()
 
-	return s.endStreamLocked()
+	return w.endStreamLocked()
 }
 
-func (s *writerImpl) endStreamLocked() ([]byte, error) {
+func (s *Writer) endStreamLocked() ([]byte, error) {
 	if s.closed {
 		return nil, ErrClosed
 	}

--- a/pkg/encoder_test.go
+++ b/pkg/encoder_test.go
@@ -56,7 +56,7 @@ func TestEncoderEndStreamFinalizes(t *testing.T) {
 
 	e, err := NewEncoder(enc)
 	require.NoError(t, err)
-	se := e.(*writerImpl)
+	se := e.writer
 
 	_, err = e.Encode([]byte("foo"))
 	require.NoError(t, err)

--- a/pkg/example_test.go
+++ b/pkg/example_test.go
@@ -16,7 +16,7 @@ func exampleFrames() [][]byte {
 	return [][]byte{[]byte("Hello"), []byte(" "), []byte("World!")}
 }
 
-func writeExampleFrames(w seekable.Writer) {
+func writeExampleFrames(w *seekable.Writer) {
 	for _, frame := range exampleFrames() {
 		if _, err := w.Write(frame); err != nil {
 			log.Fatal(err)
@@ -148,7 +148,7 @@ func ExampleNewSeekTable() {
 	// offset 7 is in frame 1
 }
 
-func ExampleConcurrentWriter_WriteMany() {
+func ExampleWriter_WriteMany() {
 	var buf bytes.Buffer
 
 	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))

--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -100,9 +100,13 @@ func (rs *readSeekerEnvImpl) ReadSkipFrame(skippableFrameOffset int64) ([]byte, 
 	return buf, nil
 }
 
-type readerImpl struct {
-	dec ZSTDDecoder
-	SeekTable
+// Reader provides sequential and random access to a seekable Zstandard stream.
+//
+// Offsets are expressed in the decompressed stream. Read and Seek use an
+// internal current offset; ReadAt does not.
+type Reader struct {
+	dec   ZSTDDecoder
+	table SeekTable
 
 	offset int64
 
@@ -116,26 +120,11 @@ type readerImpl struct {
 }
 
 var (
-	_ Reader      = (*readerImpl)(nil)
-	_ io.Seeker   = (*readerImpl)(nil)
-	_ io.Reader   = (*readerImpl)(nil)
-	_ io.ReaderAt = (*readerImpl)(nil)
-	_ io.Closer   = (*readerImpl)(nil)
+	_ io.Seeker   = (*Reader)(nil)
+	_ io.Reader   = (*Reader)(nil)
+	_ io.ReaderAt = (*Reader)(nil)
+	_ io.Closer   = (*Reader)(nil)
 )
-
-// Reader provides sequential and random access to a seekable Zstandard stream.
-//
-// Offsets are expressed in the decompressed stream. Read and Seek use an
-// internal current offset; ReadAt does not.
-type Reader interface {
-	io.Reader
-	io.ReaderAt
-	io.Seeker
-
-	// Close releases reader-owned memory and causes future Reader method calls to fail.
-	// Close is idempotent. Read, ReadAt, and Seek return ErrClosed after Close.
-	Close() error
-}
 
 // ZSTDDecoder is the decompressor.
 //
@@ -153,8 +142,8 @@ type ZSTDDecoder interface {
 //
 // NewReader reads and validates the seek table during construction. The caller
 // remains responsible for closing rs and decoder, if they require closing.
-func NewReader(rs io.ReadSeeker, decoder ZSTDDecoder, opts ...ReaderOption) (Reader, error) {
-	sr := readerImpl{
+func NewReader(rs io.ReadSeeker, decoder ZSTDDecoder, opts ...ReaderOption) (*Reader, error) {
+	sr := Reader{
 		dec: decoder,
 	}
 
@@ -183,12 +172,15 @@ func NewReader(rs io.ReadSeeker, decoder ZSTDDecoder, opts ...ReaderOption) (Rea
 		return nil, fmt.Errorf("decompressed size is too large for Reader: %d > %d", table.Size(), maxReaderOffset)
 	}
 
-	sr.SeekTable = table
+	sr.table = table
 
 	return &sr, nil
 }
 
-func (r *readerImpl) ReadAt(p []byte, off int64) (n int, err error) {
+// ReadAt reads len(p) decompressed bytes starting at off.
+//
+// ReadAt does not move the Reader's current offset.
+func (r *Reader) ReadAt(p []byte, off int64) (n int, err error) {
 	if r.closed.Load() {
 		return 0, ErrClosed
 	}
@@ -199,11 +191,12 @@ func (r *readerImpl) ReadAt(p []byte, off int64) (n int, err error) {
 	return
 }
 
-func (r *readerImpl) Read(p []byte) (n int, err error) {
+// Read reads decompressed bytes from the Reader's current offset.
+func (r *Reader) Read(p []byte) (n int, err error) {
 	offset, n, err := r.read(p, r.offset)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			r.offset = int64(r.Size())
+			r.offset = int64(r.table.Size())
 		}
 		return
 	}
@@ -211,15 +204,17 @@ func (r *readerImpl) Read(p []byte) (n int, err error) {
 	return
 }
 
-func (r *readerImpl) Close() error {
+// Close releases reader-owned memory and causes future Reader method calls to fail.
+// Close is idempotent. Read, ReadAt, and Seek return ErrClosed after Close.
+func (r *Reader) Close() error {
 	if !r.closed.Swap(true) {
 		r.cachedFrame.replace(math.MaxUint64, nil)
-		r.SeekTable = SeekTable{}
+		r.table = SeekTable{}
 	}
 	return nil
 }
 
-func (r *readerImpl) read(dst []byte, off int64) (int64, int, error) {
+func (r *Reader) read(dst []byte, off int64) (int64, int, error) {
 	if r.closed.Load() {
 		return 0, 0, ErrClosed
 	}
@@ -227,11 +222,11 @@ func (r *readerImpl) read(dst []byte, off int64) (int64, int, error) {
 	if off < 0 {
 		return 0, 0, fmt.Errorf("offset before the start of the file: %d", off)
 	}
-	if uint64(off) >= r.Size() {
+	if uint64(off) >= r.table.Size() {
 		return 0, 0, io.EOF
 	}
 
-	index, ok := r.EntryByDecompressedOffset(uint64(off))
+	index, ok := r.table.EntryByDecompressedOffset(uint64(off))
 	if !ok {
 		return 0, 0, fmt.Errorf("failed to get index by offset: %d", off)
 	}
@@ -268,7 +263,7 @@ func (r *readerImpl) read(dst []byte, off int64) (int64, int, error) {
 			return 0, 0, fmt.Errorf("failed to decompress data data at: %d, %w", index.CompressedOffset, err)
 		}
 
-		if r.checksums {
+		if r.table.HasChecksums() {
 			checksum := uint32(xxhash.Sum64(decompressed))
 			if index.Checksum != checksum {
 				return 0, 0, fmt.Errorf("checksum verification failed at: %d: expected: %d, actual: %d",
@@ -296,7 +291,8 @@ func (r *readerImpl) read(dst []byte, off int64) (int64, int, error) {
 	return off + int64(size), int(size), nil
 }
 
-func (r *readerImpl) Seek(offset int64, whence int) (int64, error) {
+// Seek updates the Reader's current offset and returns the new offset.
+func (r *Reader) Seek(offset int64, whence int) (int64, error) {
 	if r.closed.Load() {
 		return 0, ErrClosed
 	}
@@ -308,7 +304,7 @@ func (r *readerImpl) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekStart:
 		newOffset = offset
 	case io.SeekEnd:
-		newOffset = int64(r.Size()) + offset
+		newOffset = int64(r.table.Size()) + offset
 	default:
 		return 0, fmt.Errorf("unknown whence: %d", whence)
 	}

--- a/pkg/reader_options.go
+++ b/pkg/reader_options.go
@@ -3,7 +3,7 @@ package seekable
 import "log/slog"
 
 // ReaderOption configures NewReader.
-type ReaderOption func(*readerImpl) error
+type ReaderOption func(*Reader) error
 
 // WithReaderLogger sets the logger used by Reader internals.
 //
@@ -12,7 +12,7 @@ func WithReaderLogger(l *slog.Logger) ReaderOption {
 	if l == nil {
 		l = discardLogger
 	}
-	return func(r *readerImpl) error { r.logger = l; return nil }
+	return func(r *Reader) error { r.logger = l; return nil }
 }
 
 // WithReaderEnvironment sets a custom read environment for advanced storage implementations.
@@ -20,5 +20,5 @@ func WithReaderLogger(l *slog.Logger) ReaderOption {
 // When this option is supplied, NewReader uses e instead of the io.ReadSeeker
 // argument for all seek-table and frame reads.
 func WithReaderEnvironment(e ReaderEnvironment) ReaderOption {
-	return func(r *readerImpl) error { r.env = e; return nil }
+	return func(r *Reader) error { r.env = e; return nil }
 }

--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -29,7 +29,13 @@ func (w *writerEnvImpl) WriteSeekTable(p []byte) (n int, err error) {
 	return w.w.Write(p)
 }
 
-type writerImpl struct {
+// Writer writes a seekable Zstandard stream.
+//
+// Each non-empty Write call becomes one Zstandard frame in the output stream.
+// Close must be called to write the final seek-table skippable frame; without
+// it, Reader and NewSeekTable cannot find the random-access metadata.
+// Close is idempotent. Write and WriteMany return ErrClosed after Close.
+type Writer struct {
 	enc          ZSTDEncoder
 	frameEntries []seekTableEntry
 
@@ -42,55 +48,15 @@ type writerImpl struct {
 }
 
 var (
-	_ io.Writer = (*writerImpl)(nil)
-	_ io.Closer = (*writerImpl)(nil)
+	_ io.Writer = (*Writer)(nil)
+	_ io.Closer = (*Writer)(nil)
 )
-
-// Writer writes a seekable Zstandard stream.
-//
-// Each non-empty Write call becomes one Zstandard frame in the output stream.
-// Close must be called to write the final seek-table skippable frame; without
-// it, Reader and NewSeekTable cannot find the random-access metadata.
-// Close is idempotent. Write and WriteMany return ErrClosed after Close.
-type Writer interface {
-	// Write writes a chunk of data as a separate frame into the data stream.
-	//
-	// Note that Write does not do any coalescing nor splitting of data,
-	// so each non-empty write will map to a separate Zstandard frame.
-	// Empty writes do not add seek-table entries.
-	//
-	// If the underlying frame write fails or writes only part of the frame, the
-	// writer stops accepting more frames. Close may still be called to write the
-	// seek table for frames that were fully written. Bytes already accepted by
-	// the underlying writer are not rolled back.
-	Write(src []byte) (int, error)
-
-	// Close implements io.Closer. It writes the seek table, releases the in-memory
-	// frame index, and causes future Writer method calls to fail.
-	//
-	// The caller is still responsible for closing the underlying writer.
-	Close() (err error)
-}
 
 // FrameSource returns one frame of data at a time.
 //
 // When there are no more frames, it returns nil, nil. A non-nil error stops the
-// write. Empty frames are ignored by ConcurrentWriter.WriteMany.
+// write. Empty frames are ignored by Writer.WriteMany.
 type FrameSource func() ([]byte, error)
-
-// ConcurrentWriter allows writing many frames concurrently.
-type ConcurrentWriter interface {
-	Writer
-
-	// WriteMany writes many frames concurrently.
-	//
-	// It reads frames from frameSource sequentially, compresses up to the
-	// configured concurrency in parallel, and writes compressed frames in the
-	// same order returned by frameSource. Close must still be called after a
-	// successful WriteMany call to write the final seek table. Frame write
-	// failures have the same no-more-frames behavior as Writer.Write.
-	WriteMany(ctx context.Context, frameSource FrameSource, options ...WriteManyOption) error
-}
 
 // ZSTDEncoder is the compressor.
 //
@@ -107,8 +73,8 @@ type ZSTDEncoder interface {
 // they require closing.
 //
 // The resulting stream can be randomly accessed through Reader or NewSeekTable.
-func NewWriter(w io.Writer, encoder ZSTDEncoder, opts ...WriterOption) (ConcurrentWriter, error) {
-	sw := writerImpl{
+func NewWriter(w io.Writer, encoder ZSTDEncoder, opts ...WriterOption) (*Writer, error) {
+	sw := Writer{
 		enc: encoder,
 	}
 
@@ -129,7 +95,17 @@ func NewWriter(w io.Writer, encoder ZSTDEncoder, opts ...WriterOption) (Concurre
 	return &sw, nil
 }
 
-func (s *writerImpl) Write(src []byte) (int, error) {
+// Write writes a chunk of data as a separate frame into the data stream.
+//
+// Note that Write does not do any coalescing nor splitting of data, so each
+// non-empty write will map to a separate Zstandard frame. Empty writes do not
+// add seek-table entries.
+//
+// If the underlying frame write fails or writes only part of the frame, the
+// writer stops accepting more frames. Close may still be called to write the
+// seek table for frames that were fully written. Bytes already accepted by the
+// underlying writer are not rolled back.
+func (s *Writer) Write(src []byte) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -163,7 +139,11 @@ func (s *writerImpl) Write(src []byte) (int, error) {
 	return len(src), nil
 }
 
-func (s *writerImpl) Close() error {
+// Close implements io.Closer. It writes the seek table, releases the in-memory
+// frame index, and causes future Writer method calls to fail.
+//
+// The caller is still responsible for closing the underlying writer.
+func (s *Writer) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -182,7 +162,7 @@ type encodeResult struct {
 	entry seekTableEntry
 }
 
-func (s *writerImpl) writeManyEncoder(ctx context.Context, ch chan<- encodeResult, frame []byte) func() error {
+func (s *Writer) writeManyEncoder(ctx context.Context, ch chan<- encodeResult, frame []byte) func() error {
 	return func() error {
 		dst, entry, err := s.encodeOne(frame)
 		if err != nil {
@@ -200,7 +180,7 @@ func (s *writerImpl) writeManyEncoder(ctx context.Context, ch chan<- encodeResul
 	}
 }
 
-func (s *writerImpl) writeManyProducer(ctx context.Context, frameSource FrameSource, g *errgroup.Group, queue chan<- chan encodeResult) func() error {
+func (s *Writer) writeManyProducer(ctx context.Context, frameSource FrameSource, g *errgroup.Group, queue chan<- chan encodeResult) func() error {
 	return func() error {
 		for {
 			frame, err := frameSource()
@@ -231,7 +211,7 @@ func (s *writerImpl) writeManyProducer(ctx context.Context, frameSource FrameSou
 	}
 }
 
-func (s *writerImpl) writeManyConsumer(ctx context.Context, callback func(uint32), queue <-chan chan encodeResult) func() error {
+func (s *Writer) writeManyConsumer(ctx context.Context, callback func(uint32), queue <-chan chan encodeResult) func() error {
 	return func() error {
 		for {
 			var ch <-chan encodeResult
@@ -270,7 +250,14 @@ func (s *writerImpl) writeManyConsumer(ctx context.Context, callback func(uint32
 	}
 }
 
-func (s *writerImpl) WriteMany(ctx context.Context, frameSource FrameSource, options ...WriteManyOption) error {
+// WriteMany writes many frames concurrently.
+//
+// It reads frames from frameSource sequentially, compresses up to the
+// configured concurrency in parallel, and writes compressed frames in the same
+// order returned by frameSource. Close must still be called after a successful
+// WriteMany call to write the final seek table. Frame write failures have the
+// same no-more-frames behavior as Writer.Write.
+func (s *Writer) WriteMany(ctx context.Context, frameSource FrameSource, options ...WriteManyOption) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -300,7 +287,7 @@ func (s *writerImpl) WriteMany(ctx context.Context, frameSource FrameSource, opt
 	return g.Wait()
 }
 
-func (s *writerImpl) writeSeekTableLocked() error {
+func (s *Writer) writeSeekTableLocked() error {
 	seekTableBytes, err := s.endStreamLocked()
 	if err != nil {
 		return err

--- a/pkg/writer_options.go
+++ b/pkg/writer_options.go
@@ -6,7 +6,7 @@ import (
 )
 
 // WriterOption configures NewWriter and NewEncoder.
-type WriterOption func(*writerImpl) error
+type WriterOption func(*Writer) error
 
 // WithWriterLogger sets the logger used by Writer and Encoder internals.
 //
@@ -15,7 +15,7 @@ func WithWriterLogger(l *slog.Logger) WriterOption {
 	if l == nil {
 		l = discardLogger
 	}
-	return func(w *writerImpl) error { w.logger = l; return nil }
+	return func(w *Writer) error { w.logger = l; return nil }
 }
 
 // WithWriterEnvironment sets a custom write environment for advanced storage implementations.
@@ -23,7 +23,7 @@ func WithWriterLogger(l *slog.Logger) WriterOption {
 // When this option is supplied, NewWriter uses e instead of the io.Writer
 // argument for all frame and seek-table writes.
 func WithWriterEnvironment(e WriterEnvironment) WriterOption {
-	return func(w *writerImpl) error { w.env = e; return nil }
+	return func(w *Writer) error { w.env = e; return nil }
 }
 
 type writeManyOptions struct {
@@ -31,7 +31,7 @@ type writeManyOptions struct {
 	writeCallback func(uint32)
 }
 
-// WriteManyOption configures ConcurrentWriter.WriteMany.
+// WriteManyOption configures Writer.WriteMany.
 type WriteManyOption func(options *writeManyOptions) error
 
 // WithConcurrency sets the maximum number of concurrent frame encoding operations.

--- a/pkg/writer_test.go
+++ b/pkg/writer_test.go
@@ -204,11 +204,11 @@ func TestFrameWriteFailureAllowsClose(t *testing.T) {
 
 	for _, tc := range []struct {
 		name  string
-		write func(t *testing.T, w ConcurrentWriter, frames [][]byte) error
+		write func(t *testing.T, w *Writer, frames [][]byte) error
 	}{
 		{
 			name: "Write",
-			write: func(t *testing.T, w ConcurrentWriter, frames [][]byte) error {
+			write: func(t *testing.T, w *Writer, frames [][]byte) error {
 				t.Helper()
 
 				_, err := w.Write(frames[0])
@@ -219,7 +219,7 @@ func TestFrameWriteFailureAllowsClose(t *testing.T) {
 		},
 		{
 			name: "WriteMany",
-			write: func(t *testing.T, w ConcurrentWriter, frames [][]byte) error {
+			write: func(t *testing.T, w *Writer, frames [][]byte) error {
 				t.Helper()
 
 				return w.WriteMany(context.Background(), makeTestFrameSource(frames), WithConcurrency(1))
@@ -420,7 +420,7 @@ func TestWriterCloseSemantics(t *testing.T) {
 	var b bytes.Buffer
 	w, err := NewWriter(&b, enc)
 	require.NoError(t, err)
-	sw := w.(*writerImpl)
+	sw := w
 
 	_, err = w.Write([]byte("foo"))
 	require.NoError(t, err)


### PR DESCRIPTION
## Breaking Changes

This PR changes constructor return types from package-owned interfaces to concrete library-owned types.

## Migration Notes

- `NewWriter(...)` now returns `*seekable.Writer` instead of the removed `seekable.Writer` interface.
- `NewReader(...)` now returns `*seekable.Reader` instead of the removed `seekable.Reader` interface.
- `NewEncoder(...)` now returns `*seekable.Encoder` instead of the removed `seekable.Encoder` interface.
- `ConcurrentWriter` is removed; `WriteMany` is now a method on `*Writer`.
- Helpers should accept `*seekable.Writer`, `*seekable.Reader`, `*seekable.Encoder`, or smaller standard interfaces such as `io.Writer` / `io.Reader` where appropriate.

Input-side interfaces remain intentionally unchanged: `ZSTDEncoder`, `ZSTDDecoder`, `WriterEnvironment`, and `ReaderEnvironment` are still dependency contracts and extension points.

## What Changed

- Exported concrete `Writer`, `Reader`, and `Encoder` types as the constructor return values.
- Kept concrete type fields unexported.
- Moved `Writer`/`Reader`/`Encoder` method docs from removed interfaces onto concrete methods where needed.
- Made `Reader` hold its seek table privately so metadata access can be added deliberately in a follow-up.
- Updated tests, examples, and README wording.

## Why

Go libraries commonly return concrete package-owned types from constructors. This matches the shape users see in `github.com/klauspost/compress` and the standard library, such as `zstd.NewWriter(...) (*zstd.Encoder, error)`, `zstd.NewReader(...) (*zstd.Decoder, error)`, `s2.NewWriter(...) *s2.Writer`, and `gzip.NewReader(...) (*gzip.Reader, error)`.

Returning concrete types keeps the API extensible: future methods can be added to `Writer`, `Reader`, or `Encoder` without changing an exported package-owned interface.

## Validation

- `go test ./...` in `pkg`
- `go test -race ./...` in `pkg`
- `go test ./...` in `cmd/zstdseek`
- `git diff --check`
- `go doc NewWriter`, `go doc NewReader`, `go doc NewEncoder`, `go doc Writer`, `go doc Reader`, and `go doc Encoder`