### PR TITLE
pkg: expose reader seek table

### DIFF
--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -177,6 +177,16 @@ func NewReader(rs io.ReadSeeker, decoder ZSTDDecoder, opts ...ReaderOption) (*Re
 	return &sr, nil
 }
 
+// SeekTable returns the parsed seek table for this Reader.
+//
+// The returned SeekTable is immutable. SeekTable returns ErrClosed after Close.
+func (r *Reader) SeekTable() (SeekTable, error) {
+	if r.closed.Load() {
+		return SeekTable{}, ErrClosed
+	}
+	return r.table, nil
+}
+
 // ReadAt reads len(p) decompressed bytes starting at off.
 //
 // ReadAt does not move the Reader's current offset.
@@ -204,8 +214,8 @@ func (r *Reader) Read(p []byte) (n int, err error) {
 	return
 }
 
-// Close releases reader-owned memory and causes future Reader method calls to fail.
-// Close is idempotent. Read, ReadAt, and Seek return ErrClosed after Close.
+// Close releases reader-owned memory.
+// Close is idempotent. Read, ReadAt, Seek, and SeekTable return ErrClosed after Close.
 func (r *Reader) Close() error {
 	if !r.closed.Swap(true) {
 		r.cachedFrame.replace(math.MaxUint64, nil)

--- a/pkg/reader_test.go
+++ b/pkg/reader_test.go
@@ -172,6 +172,51 @@ func TestReader(t *testing.T) {
 	}
 }
 
+func TestReaderSeekTable(t *testing.T) {
+	t.Parallel()
+
+	dec, err := zstd.NewReader(nil)
+	require.NoError(t, err)
+	defer dec.Close()
+
+	for _, tc := range []struct {
+		name         string
+		buf          []byte
+		hasChecksums bool
+	}{
+		{name: "checksum", buf: checksum, hasChecksums: true},
+		{name: "no checksum", buf: noChecksum, hasChecksums: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := NewReader(&seekableBufferReaderAt{buf: tc.buf}, dec)
+			require.NoError(t, err)
+
+			table, err := r.SeekTable()
+			require.NoError(t, err)
+			assert.Equal(t, uint64(len(sourceString)), table.Size())
+			assert.Equal(t, int64(2), table.NumFrames())
+			assert.Equal(t, tc.hasChecksums, table.HasChecksums())
+
+			entry, ok := table.EntryByID(1)
+			require.True(t, ok)
+			assert.Equal(t, int64(1), entry.ID)
+			assert.Equal(t, uint64(4), entry.DecompressedOffset)
+			assert.Equal(t, uint32(5), entry.DecompressedSize)
+
+			entry, ok = table.EntryByDecompressedOffset(4)
+			require.True(t, ok)
+			assert.Equal(t, int64(1), entry.ID)
+
+			err = r.Close()
+			require.NoError(t, err)
+
+			table, err = r.SeekTable()
+			require.ErrorIs(t, err, ErrClosed)
+			assert.Equal(t, SeekTable{}, table)
+		})
+	}
+}
+
 func TestReaderPostCloseContract(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## API changes

- Add `(*Reader).SeekTable() (SeekTable, error)` so callers can inspect parsed seek-table metadata from a `Reader`.
- `SeekTable` returns `ErrClosed` after `Reader.Close`, matching the existing post-close contract for reader operations.

## Migration notes

- No existing call sites need changes unless they were depending on private implementation details.
- New callers should handle the returned error:

```go
table, err := r.SeekTable()
if err != nil {
    return err
}
```

## Testing

- `go test ./...` from `pkg`