### PR TITLE
docs: polish package godoc

### DIFF
--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -7,7 +7,8 @@
 // compressed frames followed by a final skippable frame containing a seek table.
 // Standard Zstandard decoders can read the stream from the beginning, while
 // Reader uses the seek table to serve Read, ReadAt, and Seek calls by
-// uncompressed byte offset.
+// uncompressed byte offset and exposes the parsed metadata through
+// Reader.SeekTable.
 //
 // Writer and Encoder produce seekable streams by storing each non-empty input
 // chunk as a separate Zstandard frame. Close or EndStream must be called to

--- a/pkg/environments.go
+++ b/pkg/environments.go
@@ -24,6 +24,10 @@ type ReaderEnvironment interface {
 	//
 	// The returned slice must contain exactly index.CompressedSize bytes starting
 	// at index.CompressedOffset in the compressed stream.
+	//
+	// Reader may call GetFrameByIndex concurrently from concurrent ReadAt calls.
+	// Implementations used that way must support concurrent calls and must not
+	// mutate returned slices after returning them.
 	GetFrameByIndex(index FrameOffsetEntry) ([]byte, error)
 
 	// ReadFooter returns bytes whose last 9 bytes are interpreted as a Seek_Table_Footer.

--- a/pkg/example_test.go
+++ b/pkg/example_test.go
@@ -105,6 +105,40 @@ func ExampleNewReader() {
 	// World
 }
 
+func ExampleReader_SeekTable() {
+	compressed := exampleSeekableStream()
+
+	dec, err := zstd.NewReader(nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer dec.Close()
+
+	r, err := seekable.NewReader(bytes.NewReader(compressed), dec)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		_ = r.Close()
+	}()
+
+	table, err := r.SeekTable()
+	if err != nil {
+		log.Fatal(err)
+	}
+	entry, ok := table.EntryByDecompressedOffset(6)
+	if !ok {
+		log.Fatal("missing seek-table entry")
+	}
+
+	fmt.Printf("frames=%d size=%d checksums=%t\n", table.NumFrames(), table.Size(), table.HasChecksums())
+	fmt.Printf("offset 6 is in frame %d\n", entry.ID)
+
+	// Output:
+	// frames=3 size=12 checksums=true
+	// offset 6 is in frame 2
+}
+
 func ExampleNewSeekTable() {
 	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
 	if err != nil {

--- a/pkg/frame_offset.go
+++ b/pkg/frame_offset.go
@@ -17,9 +17,11 @@ type FrameOffsetEntry struct {
 	DecompressedSize uint32
 
 	// Checksum is the lower 32 bits of the XXH64 hash of the uncompressed data.
+	// It is meaningful only when SeekTable.HasChecksums reports true.
 	Checksum uint32
 }
 
+// LogValue implements slog.LogValuer.
 func (o FrameOffsetEntry) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.Int64("ID", o.ID),

--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -100,10 +100,16 @@ func (rs *readSeekerEnvImpl) ReadSkipFrame(skippableFrameOffset int64) ([]byte, 
 	return buf, nil
 }
 
-// Reader provides sequential and random access to a seekable Zstandard stream.
+// Reader provides sequential and random access to a seekable Zstandard stream
+// and exposes its parsed seek-table metadata.
 //
 // Offsets are expressed in the decompressed stream. Read and Seek use an
 // internal current offset; ReadAt does not.
+//
+// Before Close, ReadAt and SeekTable may be called concurrently if the supplied
+// decoder and read environment support concurrent use. Read and Seek share the
+// internal current offset and should be serialized by the caller. No other
+// Reader method should be called concurrently with Close.
 type Reader struct {
 	dec   ZSTDDecoder
 	table SeekTable
@@ -130,6 +136,9 @@ var (
 //
 // It is compatible with the DecodeAll method provided by
 // github.com/klauspost/compress/zstd.
+//
+// Reader may call DecodeAll concurrently from concurrent ReadAt calls. Decoders
+// used that way must support concurrent DecodeAll calls.
 type ZSTDDecoder interface {
 	DecodeAll(input, dst []byte) ([]byte, error)
 }
@@ -180,6 +189,8 @@ func NewReader(rs io.ReadSeeker, decoder ZSTDDecoder, opts ...ReaderOption) (*Re
 // SeekTable returns the parsed seek table for this Reader.
 //
 // The returned SeekTable is immutable. SeekTable returns ErrClosed after Close.
+// Before Close, SeekTable may be called concurrently with other Reader methods
+// except Close.
 func (r *Reader) SeekTable() (SeekTable, error) {
 	if r.closed.Load() {
 		return SeekTable{}, ErrClosed
@@ -190,6 +201,8 @@ func (r *Reader) SeekTable() (SeekTable, error) {
 // ReadAt reads len(p) decompressed bytes starting at off.
 //
 // ReadAt does not move the Reader's current offset.
+// Before Close, ReadAt may be called concurrently if the supplied decoder and
+// read environment support concurrent use.
 func (r *Reader) ReadAt(p []byte, off int64) (n int, err error) {
 	if r.closed.Load() {
 		return 0, ErrClosed

--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -56,12 +56,18 @@ var (
 //
 // When there are no more frames, it returns nil, nil. A non-nil error stops the
 // write. Empty frames are ignored by Writer.WriteMany.
+//
+// WriteMany may retain each returned slice until WriteMany returns. FrameSource
+// implementations must not mutate or reuse returned slices before then.
 type FrameSource func() ([]byte, error)
 
 // ZSTDEncoder is the compressor.
 //
 // It is compatible with the EncodeAll method provided by
 // github.com/klauspost/compress/zstd.
+//
+// Writer.WriteMany may call EncodeAll concurrently. Encoders used with
+// WriteMany must support concurrent EncodeAll calls.
 type ZSTDEncoder interface {
 	EncodeAll(src, dst []byte) []byte
 }

--- a/pkg/writer_options.go
+++ b/pkg/writer_options.go
@@ -6,6 +6,7 @@ import (
 )
 
 // WriterOption configures NewWriter and NewEncoder.
+// Options that configure output environments apply only to NewWriter.
 type WriterOption func(*Writer) error
 
 // WithWriterLogger sets the logger used by Writer and Encoder internals.
@@ -20,8 +21,9 @@ func WithWriterLogger(l *slog.Logger) WriterOption {
 
 // WithWriterEnvironment sets a custom write environment for advanced storage implementations.
 //
-// When this option is supplied, NewWriter uses e instead of the io.Writer
-// argument for all frame and seek-table writes.
+// When this option is supplied to NewWriter, NewWriter uses e instead of the
+// io.Writer argument for all frame and seek-table writes. NewEncoder returns
+// compressed frames directly, so WithWriterEnvironment has no effect there.
 func WithWriterEnvironment(e WriterEnvironment) WriterOption {
 	return func(w *Writer) error { w.env = e; return nil }
 }


### PR DESCRIPTION
## Documentation changes

- Document `Reader.SeekTable` in package and reader docs.
- Add a godoc example for `Reader.SeekTable`.
- Clarify Reader concurrency and close-lifetime expectations.
- Clarify encoder/decoder/environment concurrency expectations for concurrent operations.
- Clarify `FrameSource` slice ownership during `WriteMany`.
- Document `FrameOffsetEntry.LogValue` and checksum meaning.
- Clarify that `WithWriterEnvironment` only affects `NewWriter`.
- Update README snippets to check reader errors and show seek-table metadata access.

## Behavior changes

- None. This intentionally does not add `NewWriter` nil validation.

## Testing

- `go test ./...` from `pkg`
- `go doc -all` from `pkg`