### PR TITLE
pkg: expand writemany write callback

### DIFF
--- a/pkg/encoder.go
+++ b/pkg/encoder.go
@@ -81,8 +81,8 @@ func (e *Encoder) Encode(src []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	w.logger.Debug("appending frame", slog.Any("frame", &entry))
-	w.frameEntries = append(w.frameEntries, entry)
+	frame := w.appendFrameEntry(entry)
+	w.logger.Debug("appended frame", slog.Any("frame", frame))
 	return dst, nil
 }
 
@@ -127,5 +127,7 @@ func (s *Writer) endStreamLocked() ([]byte, error) {
 
 	s.closed = true
 	s.frameEntries = nil
+	s.compressedOffset = 0
+	s.decompressedOffset = 0
 	return frame, nil
 }

--- a/pkg/example_test.go
+++ b/pkg/example_test.go
@@ -212,8 +212,8 @@ func ExampleWriter_WriteMany() {
 
 	err = w.WriteMany(context.Background(), next,
 		seekable.WithConcurrency(2),
-		seekable.WithWriteCallback(func(size uint32) {
-			fmt.Println(size)
+		seekable.WithWriteCallback(func(entry seekable.FrameOffsetEntry) {
+			fmt.Printf("%d %d\n", entry.ID, entry.DecompressedSize)
 		}),
 	)
 	if err != nil {
@@ -224,7 +224,7 @@ func ExampleWriter_WriteMany() {
 	}
 
 	// Output:
-	// 5
-	// 1
-	// 6
+	// 0 5
+	// 1 1
+	// 2 6
 }

--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -39,6 +39,9 @@ type Writer struct {
 	enc          ZSTDEncoder
 	frameEntries []seekTableEntry
 
+	compressedOffset   uint64
+	decompressedOffset uint64
+
 	logger *slog.Logger
 	env    WriterEnvironment
 	failed bool
@@ -101,6 +104,23 @@ func NewWriter(w io.Writer, encoder ZSTDEncoder, opts ...WriterOption) (*Writer,
 	return &sw, nil
 }
 
+func (s *Writer) appendFrameEntry(entry seekTableEntry) FrameOffsetEntry {
+	frame := FrameOffsetEntry{
+		ID:                 int64(len(s.frameEntries)),
+		CompressedOffset:   s.compressedOffset,
+		DecompressedOffset: s.decompressedOffset,
+		CompressedSize:     entry.CompressedSize,
+		DecompressedSize:   entry.DecompressedSize,
+		Checksum:           entry.Checksum,
+	}
+
+	s.frameEntries = append(s.frameEntries, entry)
+	s.compressedOffset += uint64(entry.CompressedSize)
+	s.decompressedOffset += uint64(entry.DecompressedSize)
+
+	return frame
+}
+
 // Write writes a chunk of data as a separate frame into the data stream.
 //
 // Note that Write does not do any coalescing nor splitting of data, so each
@@ -140,8 +160,8 @@ func (s *Writer) Write(src []byte) (int, error) {
 		return 0, fmt.Errorf("partial write: %d out of %d", n, len(dst))
 	}
 
-	s.logger.Debug("appending frame", slog.Any("frame", &entry))
-	s.frameEntries = append(s.frameEntries, entry)
+	frame := s.appendFrameEntry(entry)
+	s.logger.Debug("appended frame", slog.Any("frame", frame))
 	return len(src), nil
 }
 
@@ -159,6 +179,8 @@ func (s *Writer) Close() error {
 
 	err := s.writeSeekTableLocked()
 	s.frameEntries = nil
+	s.compressedOffset = 0
+	s.decompressedOffset = 0
 	s.env = nil
 	return err
 }
@@ -217,7 +239,7 @@ func (s *Writer) writeManyProducer(ctx context.Context, frameSource FrameSource,
 	}
 }
 
-func (s *Writer) writeManyConsumer(ctx context.Context, callback func(uint32), queue <-chan chan encodeResult) func() error {
+func (s *Writer) writeManyConsumer(ctx context.Context, callback func(FrameOffsetEntry), queue <-chan chan encodeResult) func() error {
 	return func() error {
 		for {
 			var ch <-chan encodeResult
@@ -247,10 +269,10 @@ func (s *Writer) writeManyConsumer(ctx context.Context, callback func(uint32), q
 				s.failed = true
 				return fmt.Errorf("partial write: %d out of %d", n, len(result.buf))
 			}
-			s.frameEntries = append(s.frameEntries, result.entry)
+			frame := s.appendFrameEntry(result.entry)
 
 			if callback != nil {
-				callback(result.entry.DecompressedSize)
+				callback(frame)
 			}
 		}
 	}
@@ -289,7 +311,7 @@ func (s *Writer) WriteMany(ctx context.Context, frameSource FrameSource, options
 	// Add extra room in the queue, so we can keep throughput high even if blocks finish out of order
 	queue := make(chan chan encodeResult, opts.concurrency*2)
 	g.Go(s.writeManyProducer(gCtx, frameSource, g, queue))
-	g.Go(s.writeManyConsumer(gCtx, opts.writeCallback, queue))
+	g.Go(s.writeManyConsumer(gCtx, opts.frameCallback, queue))
 	return g.Wait()
 }
 

--- a/pkg/writer_options.go
+++ b/pkg/writer_options.go
@@ -30,7 +30,7 @@ func WithWriterEnvironment(e WriterEnvironment) WriterOption {
 
 type writeManyOptions struct {
 	concurrency   int
-	writeCallback func(uint32)
+	frameCallback func(FrameOffsetEntry)
 }
 
 // WriteManyOption configures Writer.WriteMany.
@@ -49,13 +49,17 @@ func WithConcurrency(concurrency int) WriteManyOption {
 	}
 }
 
-// WithWriteCallback calls cb after each frame is written.
+// WithWriteCallback calls cb after each non-empty frame is written.
 //
-// cb receives the decompressed size of the frame that was just written. It is
-// called in stream order from the WriteMany writer goroutine.
-func WithWriteCallback(cb func(size uint32)) WriteManyOption {
+// cb receives the seek-table entry for the frame that was just written. It is
+// called in stream order from the WriteMany writer goroutine, after the frame
+// has been written and added to the Writer's in-memory seek table.
+//
+// cb must not call methods on the same Writer. To stop WriteMany from cb,
+// cancel the WriteMany context or make the FrameSource return an error.
+func WithWriteCallback(cb func(entry FrameOffsetEntry)) WriteManyOption {
 	return func(options *writeManyOptions) error {
-		options.writeCallback = cb
+		options.frameCallback = cb
 		return nil
 	}
 }

--- a/pkg/writer_test.go
+++ b/pkg/writer_test.go
@@ -97,12 +97,24 @@ func TestConcurrentWriter(t *testing.T) {
 	concurrentWriter, err := NewWriter(bw, enc)
 	require.NoError(t, err)
 
+	var compressedWritten uint64
 	var totalWritten int
+	var callbackErr error
 	err = concurrentWriter.WriteMany(ctx, makeTestFrameSource(frames), WithConcurrency(5),
-		WithWriteCallback(func(size uint32) {
-			totalWritten += int(size)
+		WithWriteCallback(func(entry FrameOffsetEntry) {
+			if entry.CompressedOffset != compressedWritten {
+				callbackErr = fmt.Errorf("unexpected compressed offset: %d != %d", entry.CompressedOffset, compressedWritten)
+				return
+			}
+			if entry.DecompressedOffset != uint64(totalWritten) {
+				callbackErr = fmt.Errorf("unexpected decompressed offset: %d != %d", entry.DecompressedOffset, totalWritten)
+				return
+			}
+			compressedWritten += uint64(entry.CompressedSize)
+			totalWritten += int(entry.DecompressedSize)
 		}))
 	require.NoError(t, err)
+	require.NoError(t, callbackErr)
 	require.Equal(t, len(concat), totalWritten)
 
 	// Write one at a time
@@ -286,7 +298,7 @@ func TestConcurrentWriterCancellation(t *testing.T) {
 		frames = append(frames, []byte(fmt.Sprintf("test%d", i)))
 	}
 
-	err = w.WriteMany(ctx, makeTestFrameSource(frames), WithConcurrency(1), WithWriteCallback(func(uint32) {
+	err = w.WriteMany(ctx, makeTestFrameSource(frames), WithConcurrency(1), WithWriteCallback(func(FrameOffsetEntry) {
 		cancel(cause)
 	}))
 	assert.ErrorIs(t, err, cause)


### PR DESCRIPTION
## Breaking changes

- Changes `WithWriteCallback` from `func(size uint32)` to `func(entry FrameOffsetEntry)`.
- The callback now receives the full public frame metadata instead of only the decompressed frame size.
- The callback remains observational: it does not return an error. To stop `WriteMany`, cancel the `context.Context` passed to `WriteMany` or make the `FrameSource` return an error.

## Migration notes

Before:

```go
err := w.WriteMany(ctx, source,
    seekable.WithWriteCallback(func(size uint32) {
        written += int(size)
    }),
)
```

After:

```go
err := w.WriteMany(ctx, source,
    seekable.WithWriteCallback(func(entry seekable.FrameOffsetEntry) {
        written += int(entry.DecompressedSize)
    }),
)
```

For richer progress/reporting, use `entry.ID`, `entry.CompressedOffset`, `entry.DecompressedOffset`, `entry.CompressedSize`, `entry.DecompressedSize`, and `entry.Checksum`.

## Notes

- `cmd/zstdseek` is intentionally not updated in this PR. It remains pinned to the released package dependency and should be updated separately after the package dependency is bumped.
- The callback is called after each non-empty frame is written and added to the in-memory seek table, in stream order, from the `WriteMany` writer goroutine.

## Testing

- `go test ./...` from `pkg`
- `git diff --check`