### PR TITLE
pkg: preserve reader offset on eof

### DIFF
--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -218,9 +218,6 @@ func (r *Reader) ReadAt(p []byte, off int64) (n int, err error) {
 func (r *Reader) Read(p []byte) (n int, err error) {
 	offset, n, err := r.read(p, r.offset)
 	if err != nil {
-		if errors.Is(err, io.EOF) {
-			r.offset = int64(r.table.Size())
-		}
 		return
 	}
 	r.offset = offset

--- a/pkg/reader_test.go
+++ b/pkg/reader_test.go
@@ -581,6 +581,10 @@ func TestNoReaderAt(t *testing.T) {
 
 			_, err = r.Read(tmp)
 			require.ErrorIs(t, err, io.EOF)
+
+			m, err = r.Seek(0, io.SeekCurrent)
+			require.NoError(t, err)
+			assert.Equal(t, int64(999), m)
 		})
 	}
 }


### PR DESCRIPTION
## Bug fix

- Preserve `Reader`'s current offset when `Read` returns `io.EOF`.
- This fixes `Seek` semantics for positions beyond the decompressed stream end: after `Seek(999, io.SeekStart)`, a failed `Read` no longer clamps the current offset back to `SeekTable.Size()`.

## Regression test

- Added an assertion to the existing `TestNoReaderAt` EOF path.
- Verified the new assertion failed before the fix with actual offset `9` instead of `999`.

## Testing

- `go test -run TestNoReaderAt ./...` from `pkg`
- `go test ./...` from `pkg`
- `git diff --check`