### PR TITLE
pkg: short-circuit empty reader reads

### DIFF
--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -238,6 +238,9 @@ func (r *Reader) read(dst []byte, off int64) (int64, int, error) {
 	if r.closed.Load() {
 		return 0, 0, ErrClosed
 	}
+	if len(dst) == 0 {
+		return off, 0, nil
+	}
 
 	if off < 0 {
 		return 0, 0, fmt.Errorf("offset before the start of the file: %d", off)

--- a/pkg/reader_test.go
+++ b/pkg/reader_test.go
@@ -163,6 +163,17 @@ func TestReader(t *testing.T) {
 		_, err = r.Read(tmp)
 		require.ErrorIs(t, err, io.EOF)
 
+		offset, err := r.Seek(0, io.SeekCurrent)
+		require.NoError(t, err)
+
+		n, err = r.Read(nil)
+		require.NoError(t, err)
+		assert.Equal(t, 0, n)
+
+		newOffset, err := r.Seek(0, io.SeekCurrent)
+		require.NoError(t, err)
+		assert.Equal(t, offset, newOffset)
+
 		err = r.Close()
 		require.NoError(t, err)
 
@@ -336,6 +347,13 @@ func TestReaderEdges(t *testing.T) {
 
 						tmp := make([]byte, m)
 						k, err := r.Read(tmp)
+						if m == 0 {
+							require.NoErrorf(t, err,
+								"%d: should not error on zero-length read at %d, len(source): %d, whence: %d",
+								i, n, len(source), whence)
+							assert.Equal(t, 0, k)
+							continue
+						}
 						if n >= int64(len(source)) {
 							require.ErrorIsf(t, err, io.EOF,
 								"%d: should return EOF at %d, len(source): %d, len(tmp): %d, k: %d, whence: %d",


### PR DESCRIPTION
## Summary

- Return `0, nil` from `Reader.Read` when called with an empty buffer.
- Keep the documented post-close behavior by returning `ErrClosed` before the empty-buffer short-circuit.
- Update reader edge tests so zero-length reads are treated as no-ops at and past EOF.

## Testing

- `go test -run 'TestReader|TestReaderEdges' ./...` from `pkg`
- `go test ./...` from `pkg`
- `git diff --check`