### PR TITLE
pkg: stop writemany after cancellation

### DIFF
--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -211,6 +211,12 @@ func (s *Writer) writeManyEncoder(ctx context.Context, ch chan<- encodeResult, f
 func (s *Writer) writeManyProducer(ctx context.Context, frameSource FrameSource, g *errgroup.Group, queue chan<- chan encodeResult) func() error {
 	return func() error {
 		for {
+			select {
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			default:
+			}
+
 			frame, err := frameSource()
 			if err != nil {
 				return fmt.Errorf("frame source failed: %w", err)

--- a/pkg/writer_test.go
+++ b/pkg/writer_test.go
@@ -304,6 +304,39 @@ func TestConcurrentWriterCancellation(t *testing.T) {
 	assert.ErrorIs(t, err, cause)
 }
 
+func TestWriteManyEmptyFramesObserveCancellation(t *testing.T) {
+	t.Parallel()
+
+	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
+	require.NoError(t, err)
+
+	var b bytes.Buffer
+	w, err := NewWriter(&b, enc)
+	require.NoError(t, err)
+
+	cause := errors.New("stop after empty frame")
+	ignored := errors.New("frame source kept running after cancellation")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	calls := 0
+	frameSource := func() ([]byte, error) {
+		calls++
+		if calls == 1 {
+			cancel(cause)
+			return []byte{}, nil
+		}
+		if calls > 10 {
+			return nil, ignored
+		}
+		return []byte{}, nil
+	}
+
+	err = w.WriteMany(ctx, frameSource, WithConcurrency(1))
+	require.ErrorIs(t, err, cause)
+	assert.Equal(t, 1, calls)
+}
+
 type fakeWriteEnvironment struct {
 	bw io.Writer
 }


### PR DESCRIPTION
## Bug fix

Fixes: https://github.com/SaveTheRbtz/zstd-seekable-format-go/pull/201

- Check `ctx.Done()` before each `FrameSource` poll in `WriteMany`'s producer loop.
- This prevents empty-frame sources from spinning after cancellation, since the empty-frame `continue` now returns to a cancellation check before polling again.

## Regression test

- Added a source that cancels after returning one empty frame, then keeps returning empty frames unless cancellation is observed.
- Verified the test failed before the fix by polling the source 11 times after cancellation.

## Testing

- `go test -run TestWriteManyEmptyFramesObserveCancellation ./...` from `pkg`
- `go test -run 'Test.*Writer|TestWriteMany|TestConcurrentWriter' ./...` from `pkg`
- `go test ./...` from `pkg`
- `git diff --check`