### PR TITLE
cmd: bump zstdseek pkg dependency

### DIFF
--- a/cmd/zstdseek/go.mod
+++ b/cmd/zstdseek/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/SaveTheRbtz/fastcdc-go v0.3.0
-	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.1-0.20260602065614-d67e900dbcf7
+	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.1-0.20260602114314-163b998318aa
 	github.com/klauspost/compress v1.18.6
 	github.com/schollz/progressbar/v3 v3.19.0
 	golang.org/x/term v0.43.0

--- a/cmd/zstdseek/go.sum
+++ b/cmd/zstdseek/go.sum
@@ -1,7 +1,7 @@
 github.com/SaveTheRbtz/fastcdc-go v0.3.0 h1:JdHvLlnijDuisYIwpRDcHZEjbxvCqtEmJ3gf35VJBgA=
 github.com/SaveTheRbtz/fastcdc-go v0.3.0/go.mod h1:2kMKqvBv1h9wCaUfETqsVkSESsCiFhp4YyEHyz7/SfE=
-github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.1-0.20260602065614-d67e900dbcf7 h1:v+SGGXz/XSqTUG+ywKQxDwqNhB7xhJ8juQYVy8ALfPQ=
-github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.1-0.20260602065614-d67e900dbcf7/go.mod h1:I28hc9eaiqKCoOB+9Wh/P1IOScfm0xCgyWC6DAo0lmo=
+github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.1-0.20260602114314-163b998318aa h1:SqSNer1Kf2yUEpl+tTIvPmJ5XpPaXZhNLCI067oFnFs=
+github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.9.1-0.20260602114314-163b998318aa/go.mod h1:I28hc9eaiqKCoOB+9Wh/P1IOScfm0xCgyWC6DAo0lmo=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chengxilo/virtualterm v1.0.4 h1:Z6IpERbRVlfB8WkOmtbHiDbBANU7cimRIof7mk9/PwM=

--- a/cmd/zstdseek/main.go
+++ b/cmd/zstdseek/main.go
@@ -177,8 +177,8 @@ func main() {
 		return bytes.Clone(chunk.Data), nil
 	}
 
-	err = w.WriteMany(ctx, frameSource, seekable.WithWriteCallback(func(size uint32) {
-		_ = bar.Add(int(size))
+	err = w.WriteMany(ctx, frameSource, seekable.WithWriteCallback(func(entry seekable.FrameOffsetEntry) {
+		_ = bar.Add(int(entry.DecompressedSize))
 	}))
 	if err != nil {
 		fatal("failed to write data", slog.Any("error", err))


### PR DESCRIPTION
## Summary

- Bump `cmd/zstdseek` to `pkg` pseudo-version `v0.9.1-0.20260602114314-163b998318aa`.
- Update the `WithWriteCallback` call for the new `func(FrameOffsetEntry)` API.
- Preserve the existing progress behavior by adding `entry.DecompressedSize` to the progress bar, matching the old callback's decompressed-size value.

## Testing

- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go test ./...` from `cmd/zstdseek`
- `go test ./...` from `pkg`
- `git diff --check`