### PR TITLE
pkg: bound footer parse errors

### DIFF
--- a/pkg/seek_table_parser.go
+++ b/pkg/seek_table_parser.go
@@ -82,8 +82,10 @@ func parseSeekTableFooter(buf []byte) (seekTableFooter, int64, error) {
 	}
 
 	footer := seekTableFooter{}
-	if err := footer.UnmarshalBinary(buf[len(buf)-seekTableFooterOffset:]); err != nil {
-		return seekTableFooter{}, 0, fmt.Errorf("failed to parse footer %+v: %w", buf, err)
+	footerBuf := buf[len(buf)-seekTableFooterOffset:]
+	if err := footer.UnmarshalBinary(footerBuf); err != nil {
+		return seekTableFooter{}, 0, fmt.Errorf("failed to parse footer: input len=%d footer excerpt=%+v: %w",
+			len(buf), footerBuf, err)
 	}
 
 	return footer, seekTableEntrySize(footer.SeekTableDescriptor.ChecksumFlag), nil

--- a/pkg/seek_table_parser_test.go
+++ b/pkg/seek_table_parser_test.go
@@ -138,6 +138,19 @@ func TestSeekTableFooterParsing(t *testing.T) {
 	}
 }
 
+func TestParseSeekTableFooterErrorIsBounded(t *testing.T) {
+	t.Parallel()
+
+	buf := make([]byte, 64<<10)
+	copy(buf[len(buf)-seekTableFooterOffset:], []byte{0x00, 0x00, 0x00, 0x00, 0x80, 0xea, 0x92, 0x8f, 0x00})
+
+	_, _, err := parseSeekTableFooter(buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "input len=65536")
+	assert.Contains(t, err.Error(), "footer excerpt")
+	assert.Less(t, len(err.Error()), 512)
+}
+
 func seekTableFooterBytes(descriptor byte) []byte {
 	return []byte{
 		0x00, 0x00, 0x00, 0x00,


### PR DESCRIPTION
## Bug fix

- Stop formatting the full caller-supplied buffer when footer parsing fails.
- Report the input length plus the bounded footer-sized excerpt passed to `UnmarshalBinary`.
- This prevents malformed large `NewSeekTable` inputs from producing huge error strings.

## Regression test

- Added a 64 KiB malformed footer input and assert the resulting error stays under 512 bytes.
- Verified the test failed before the fix with a 131,149-byte error string.

## Testing

- `go test -run TestParseSeekTableFooterErrorIsBounded ./...` from `pkg`
- `go test -run 'TestParseSeekTable|TestSeekTableFooter|TestNewSeekTable' ./...` from `pkg`
- `go test ./...` from `pkg`
- `git diff --check`