### PR TITLE
pkg: avoid disabled debug log allocations

### DIFF
--- a/pkg/encoder.go
+++ b/pkg/encoder.go
@@ -1,6 +1,7 @@
 package seekable
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
@@ -82,7 +83,9 @@ func (e *Encoder) Encode(src []byte) ([]byte, error) {
 	}
 
 	frame := w.appendFrameEntry(entry)
-	w.logger.Debug("appended frame", slog.Any("frame", frame))
+	if w.logger.Enabled(context.Background(), slog.LevelDebug) {
+		w.logger.LogAttrs(context.Background(), slog.LevelDebug, "appended frame", slog.Any("frame", frame))
+	}
 	return dst, nil
 }
 

--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -1,6 +1,7 @@
 package seekable
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -304,8 +305,16 @@ func (r *Reader) read(dst []byte, off int64) (int64, int, error) {
 		size = uint64(len(dst))
 	}
 
-	r.logger.Debug("decompressed", slog.Uint64("offsetWithinFrame", offsetWithinFrame), slog.Uint64("end", offsetWithinFrame+size),
-		slog.Uint64("size", size), slog.Int("lenDecompressed", len(decompressed)), slog.Int("lenDst", len(dst)), slog.Any("index", index))
+	if r.logger.Enabled(context.Background(), slog.LevelDebug) {
+		r.logger.LogAttrs(context.Background(), slog.LevelDebug, "decompressed",
+			slog.Uint64("offsetWithinFrame", offsetWithinFrame),
+			slog.Uint64("end", offsetWithinFrame+size),
+			slog.Uint64("size", size),
+			slog.Int("lenDecompressed", len(decompressed)),
+			slog.Int("lenDst", len(dst)),
+			slog.Any("index", index),
+		)
+	}
 	copy(dst, decompressed[offsetWithinFrame:offsetWithinFrame+size])
 
 	return off + int64(size), int(size), nil

--- a/pkg/writer.go
+++ b/pkg/writer.go
@@ -161,7 +161,9 @@ func (s *Writer) Write(src []byte) (int, error) {
 	}
 
 	frame := s.appendFrameEntry(entry)
-	s.logger.Debug("appended frame", slog.Any("frame", frame))
+	if s.logger.Enabled(context.Background(), slog.LevelDebug) {
+		s.logger.LogAttrs(context.Background(), slog.LevelDebug, "appended frame", slog.Any("frame", frame))
+	}
 	return len(src), nil
 }
 


### PR DESCRIPTION
## Summary

This avoids building debug-log attributes on hot paths when debug logging is disabled. The reader `decompressed` log is the important case: it used to construct several `slog.Attr` values, including `slog.Any("index", index)`, on every read even when the default discard logger was in use.

`Reader`, `Writer`, and `Encoder` now check `Logger.Enabled` before constructing those debug attributes and use `LogAttrs` when the log is actually emitted.

## Correctness Notes

There is no public API change. Debug log messages and fields are preserved for enabled debug loggers; disabled debug loggers skip attribute construction entirely.

## Benchmarks

In the reader-cache benchmark, this standalone change removes the largest allocation source in `Reader.read`. A representative run reduced `BenchmarkReaderFrameCache/Uniform/FIFO_MaxFrames=10000` from roughly `464 B/op, 10 allocs/op` to roughly `128 B/op, 3 allocs/op`; high-hit Zipf cases reached `0 allocs/op`.

## Tests

`go test ./...`