### PR TITLE
pkg: recycle compressed read buffers

### DIFF
--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -17,10 +17,15 @@ const maxReaderOffset = uint64(1<<63 - 1)
 type readSeekerEnvImpl struct {
 	rs io.ReadSeeker
 	mu sync.Mutex
+
+	frameBuffersMu sync.Mutex
+	frameBuffers   [][]byte
 }
 
+const maxRecycledFrameBuffers = 64
+
 func (rs *readSeekerEnvImpl) GetFrameByIndex(index FrameOffsetEntry) ([]byte, error) {
-	p := make([]byte, index.CompressedSize)
+	p := rs.frameBuffer(int(index.CompressedSize))
 	off := int64(index.CompressedOffset)
 
 	switch v := rs.rs.(type) {
@@ -46,6 +51,30 @@ func (rs *readSeekerEnvImpl) GetFrameByIndex(index FrameOffsetEntry) ([]byte, er
 	}
 
 	return p, nil
+}
+
+func (rs *readSeekerEnvImpl) frameBuffer(size int) []byte {
+	rs.frameBuffersMu.Lock()
+	for len(rs.frameBuffers) > 0 {
+		last := len(rs.frameBuffers) - 1
+		buf := rs.frameBuffers[last]
+		rs.frameBuffers[last] = nil
+		rs.frameBuffers = rs.frameBuffers[:last]
+		if cap(buf) >= size {
+			rs.frameBuffersMu.Unlock()
+			return buf[:size]
+		}
+	}
+	rs.frameBuffersMu.Unlock()
+	return make([]byte, size)
+}
+
+func (rs *readSeekerEnvImpl) RecycleFrameBuffer(buf []byte) {
+	rs.frameBuffersMu.Lock()
+	if len(rs.frameBuffers) < maxRecycledFrameBuffers {
+		rs.frameBuffers = append(rs.frameBuffers, buf[:0])
+	}
+	rs.frameBuffersMu.Unlock()
 }
 
 func (rs *readSeekerEnvImpl) ReadFooter() ([]byte, error) {
@@ -100,6 +129,10 @@ type Reader struct {
 	closed atomic.Bool
 
 	frameCache *readerFrameCache
+}
+
+type frameBufferRecycler interface {
+	RecycleFrameBuffer([]byte)
 }
 
 var (
@@ -272,15 +305,28 @@ func (r *Reader) read(dst []byte, off int64) (int64, int, error) {
 		if err != nil {
 			return 0, 0, fmt.Errorf("failed to read compressed data at: %d, %w", index.CompressedOffset, err)
 		}
+		var recycler frameBufferRecycler
+		if fb, ok := r.env.(frameBufferRecycler); ok {
+			recycler = fb
+		}
 
 		if len(src) != int(index.CompressedSize) {
+			if recycler != nil {
+				recycler.RecycleFrameBuffer(src)
+			}
 			return 0, 0, fmt.Errorf("compressed size does not match index at: %d: expected: %d, index: %+v",
 				off, len(src), index)
 		}
 
 		decompressed, err = r.dec.DecodeAll(src, nil)
 		if err != nil {
+			if recycler != nil {
+				recycler.RecycleFrameBuffer(src)
+			}
 			return 0, 0, fmt.Errorf("failed to decompress data data at: %d, %w", index.CompressedOffset, err)
+		}
+		if recycler != nil {
+			recycler.RecycleFrameBuffer(src)
 		}
 
 		if r.table.HasChecksums() {


### PR DESCRIPTION
## Summary

This adds bounded internal recycling for compressed-frame read buffers in the default `io.ReadSeeker` reader environment. `readSeekerEnvImpl.GetFrameByIndex` now borrows a buffer instead of allocating a fresh slice for every cache miss, and `Reader.read` returns that buffer after decompression.

## Ownership And Concurrency

This only changes the built-in read environment. Custom `ReaderEnvironment` implementations keep the existing contract and are not asked to recycle returned slices.

The recycler is private to one `Reader` environment, guarded by a mutex, and bounded to avoid retaining an unbounded number of frame buffers.

## Correctness Notes

The compressed buffer is recycled only after `DecodeAll` has returned. The decompressed data stored in the frame cache is separate from the compressed read buffer.

## Benchmarks

This targets the allocation previously attributed to `readSeekerEnvImpl.GetFrameByIndex` at the `make([]byte, index.CompressedSize)` call. In the combined reader-cache allocation work, this removes one miss-side allocation from the built-in reader environment.

## Tests

`go test ./...`