### PR TITLE
pkg: recycle decoded reader buffers

### DIFF
--- a/pkg/framecache/fifo.go
+++ b/pkg/framecache/fifo.go
@@ -37,20 +37,28 @@ func (c *FIFO) Get(frameID int64) ([]byte, bool) {
 // Put stores data for frameID as a new FIFO insertion, replacing any existing
 // entry.
 func (c *FIFO) Put(frameID int64, data []byte) {
+	_, _ = c.PutWithEvicted(frameID, data)
+}
+
+// PutWithEvicted stores data and returns one evicted frame buffer, if any.
+func (c *FIFO) PutWithEvicted(frameID int64, data []byte) ([]byte, bool) {
 	size := uint64(len(data))
 	if !c.limits.canStore(size) {
-		c.remove(frameID)
-		return
+		return c.remove(frameID), false
 	}
 
+	var evicted []byte
 	if elem, ok := c.items[frameID]; ok {
-		c.removeElement(elem)
+		evicted = c.removeElement(elem)
 	}
 
-	c.evictFor(1, size)
+	if removed := c.evictFor(1, size); removed != nil {
+		evicted = removed
+	}
 	entry := &fifoEntry{frameID: frameID, data: data}
 	c.items[frameID] = c.order.PushBack(entry)
 	c.bytes += uint64(len(entry.data))
+	return evicted, true
 }
 
 // Clear removes all cached frames.
@@ -60,27 +68,30 @@ func (c *FIFO) Clear() {
 	c.bytes = 0
 }
 
-func (c *FIFO) remove(frameID int64) {
+func (c *FIFO) remove(frameID int64) []byte {
 	elem, ok := c.items[frameID]
 	if !ok {
-		return
+		return nil
 	}
-	c.removeElement(elem)
+	return c.removeElement(elem)
 }
 
-func (c *FIFO) removeElement(elem *list.Element) {
+func (c *FIFO) removeElement(elem *list.Element) []byte {
 	entry := elem.Value.(*fifoEntry)
 	delete(c.items, entry.frameID)
 	c.bytes -= uint64(len(entry.data))
 	c.order.Remove(elem)
+	return entry.data
 }
 
-func (c *FIFO) evictFor(extraFrames int, extraBytes uint64) {
+func (c *FIFO) evictFor(extraFrames int, extraBytes uint64) []byte {
+	var evicted []byte
 	for c.limits.overLimits(c.order.Len()+extraFrames, c.bytes+extraBytes) {
 		elem := c.order.Front()
 		if elem == nil {
-			return
+			return evicted
 		}
-		c.removeElement(elem)
+		evicted = c.removeElement(elem)
 	}
+	return evicted
 }

--- a/pkg/framecache/lru.go
+++ b/pkg/framecache/lru.go
@@ -39,26 +39,33 @@ func (c *LRU) Get(frameID int64) ([]byte, bool) {
 // Put stores data for frameID, replacing any existing frame and marking it most
 // recently used.
 func (c *LRU) Put(frameID int64, data []byte) {
+	_, _ = c.PutWithEvicted(frameID, data)
+}
+
+// PutWithEvicted stores data and returns one evicted frame buffer, if any.
+func (c *LRU) PutWithEvicted(frameID int64, data []byte) ([]byte, bool) {
 	size := uint64(len(data))
 	if !c.limits.canStore(size) {
-		c.remove(frameID)
-		return
+		return c.remove(frameID), false
 	}
 
 	if elem, ok := c.items[frameID]; ok {
 		entry := elem.Value.(*lruEntry)
+		evicted := entry.data
 		c.bytes -= uint64(len(entry.data))
 		entry.data = data
 		c.bytes += size
 		c.order.MoveToFront(elem)
-		c.evict()
-		return
+		if removed := c.evict(); removed != nil {
+			evicted = removed
+		}
+		return evicted, true
 	}
 
 	entry := &lruEntry{frameID: frameID, data: data}
 	c.items[frameID] = c.order.PushFront(entry)
 	c.bytes += uint64(len(entry.data))
-	c.evict()
+	return c.evict(), true
 }
 
 // Clear removes all cached frames.
@@ -68,27 +75,30 @@ func (c *LRU) Clear() {
 	c.bytes = 0
 }
 
-func (c *LRU) remove(frameID int64) {
+func (c *LRU) remove(frameID int64) []byte {
 	elem, ok := c.items[frameID]
 	if !ok {
-		return
+		return nil
 	}
-	c.removeElement(elem)
+	return c.removeElement(elem)
 }
 
-func (c *LRU) removeElement(elem *list.Element) {
+func (c *LRU) removeElement(elem *list.Element) []byte {
 	entry := elem.Value.(*lruEntry)
 	delete(c.items, entry.frameID)
 	c.bytes -= uint64(len(entry.data))
 	c.order.Remove(elem)
+	return entry.data
 }
 
-func (c *LRU) evict() {
+func (c *LRU) evict() []byte {
+	var evicted []byte
 	for c.limits.overLimits(c.order.Len(), c.bytes) {
 		elem := c.order.Back()
 		if elem == nil {
-			return
+			return evicted
 		}
-		c.removeElement(elem)
+		evicted = c.removeElement(elem)
 	}
+	return evicted
 }

--- a/pkg/framecache/sieve.go
+++ b/pkg/framecache/sieve.go
@@ -45,23 +45,30 @@ func (c *Sieve) Get(frameID int64) ([]byte, bool) {
 
 // Put stores data for frameID, replacing any existing entry.
 func (c *Sieve) Put(frameID int64, data []byte) {
+	_, _ = c.PutWithEvicted(frameID, data)
+}
+
+// PutWithEvicted stores data and returns one evicted frame buffer, if any.
+func (c *Sieve) PutWithEvicted(frameID int64, data []byte) ([]byte, bool) {
 	size := uint64(len(data))
 	if !c.limits.canStore(size) {
-		c.remove(frameID)
-		return
+		return c.remove(frameID), false
 	}
 
 	if elem, ok := c.items[frameID]; ok {
 		entry := elem.Value.(*sieveEntry)
+		evicted := entry.data
 		c.bytes -= uint64(len(entry.data))
 		entry.data = data
 		entry.touch()
 		c.bytes += size
-		c.evictForExcept(0, 0, elem)
-		return
+		if removed := c.evictForExcept(0, 0, elem); removed != nil {
+			evicted = removed
+		}
+		return evicted, true
 	}
 
-	c.evictFor(1, size)
+	evicted := c.evictFor(1, size)
 	entry := &sieveEntry{frameID: frameID, data: data}
 	elem := c.order.PushFront(entry)
 	c.items[frameID] = elem
@@ -69,6 +76,7 @@ func (c *Sieve) Put(frameID int64, data []byte) {
 	if c.hand == nil {
 		c.hand = c.order.Back()
 	}
+	return evicted, true
 }
 
 // Clear removes all cached frames.
@@ -79,15 +87,15 @@ func (c *Sieve) Clear() {
 	c.bytes = 0
 }
 
-func (c *Sieve) remove(frameID int64) {
+func (c *Sieve) remove(frameID int64) []byte {
 	elem, ok := c.items[frameID]
 	if !ok {
-		return
+		return nil
 	}
-	c.removeElement(elem)
+	return c.removeElement(elem)
 }
 
-func (c *Sieve) removeElement(elem *list.Element) {
+func (c *Sieve) removeElement(elem *list.Element) []byte {
 	next := c.prevCircular(elem)
 	entry := elem.Value.(*sieveEntry)
 	delete(c.items, entry.frameID)
@@ -104,26 +112,28 @@ func (c *Sieve) removeElement(elem *list.Element) {
 			c.hand = c.order.Back()
 		}
 	}
+	return entry.data
 }
 
-func (c *Sieve) evictFor(extraFrames int, extraBytes uint64) {
-	c.evictForExcept(extraFrames, extraBytes, nil)
+func (c *Sieve) evictFor(extraFrames int, extraBytes uint64) []byte {
+	return c.evictForExcept(extraFrames, extraBytes, nil)
 }
 
-func (c *Sieve) evictForExcept(extraFrames int, extraBytes uint64, protected *list.Element) {
+func (c *Sieve) evictForExcept(extraFrames int, extraBytes uint64, protected *list.Element) []byte {
+	var evicted []byte
 	for c.limits.overLimits(c.order.Len()+extraFrames, c.bytes+extraBytes) {
 		if c.hand == nil {
 			c.hand = c.order.Back()
 		}
 		if c.hand == nil {
-			return
+			return evicted
 		}
 
 		elem := c.hand
 		if elem == protected {
 			next := c.prevCircular(elem)
 			if next == nil {
-				return
+				return evicted
 			}
 			c.hand = next
 			continue
@@ -139,8 +149,9 @@ func (c *Sieve) evictForExcept(extraFrames int, extraBytes uint64, protected *li
 			continue
 		}
 
-		c.removeElement(elem)
+		evicted = c.removeElement(elem)
 	}
+	return evicted
 }
 
 func (entry *sieveEntry) touch() {

--- a/pkg/reader.go
+++ b/pkg/reader.go
@@ -100,7 +100,12 @@ type Reader struct {
 	closed atomic.Bool
 
 	frameCache *readerFrameCache
+
+	decodedBuffersMu sync.Mutex
+	decodedBuffers   [][]byte
 }
+
+const maxRecycledDecodedBuffers = 64
 
 var (
 	_ io.Seeker   = (*Reader)(nil)
@@ -229,8 +234,49 @@ func (r *Reader) Close() error {
 		}
 		r.frameCache = nil
 		r.table = SeekTable{}
+		r.decodedBuffersMu.Lock()
+		r.decodedBuffers = nil
+		r.decodedBuffersMu.Unlock()
 	}
 	return nil
+}
+
+func (r *Reader) decodedFrameBuffer(size int) []byte {
+	r.decodedBuffersMu.Lock()
+	for len(r.decodedBuffers) > 0 {
+		last := len(r.decodedBuffers) - 1
+		buf := r.decodedBuffers[last]
+		r.decodedBuffers[last] = nil
+		r.decodedBuffers = r.decodedBuffers[:last]
+		if cap(buf) >= size {
+			r.decodedBuffersMu.Unlock()
+			return buf[:0]
+		}
+	}
+	r.decodedBuffersMu.Unlock()
+	return make([]byte, 0, size)
+}
+
+func (r *Reader) recycleDecodedFrameBuffer(buf []byte) {
+	r.decodedBuffersMu.Lock()
+	if len(r.decodedBuffers) < maxRecycledDecodedBuffers {
+		r.decodedBuffers = append(r.decodedBuffers, buf[:0])
+	}
+	r.decodedBuffersMu.Unlock()
+}
+
+func sameSliceData(a, b []byte) bool {
+	if cap(a) == 0 || cap(b) == 0 {
+		return false
+	}
+	return &a[:1][0] == &b[:1][0]
+}
+
+func (r *Reader) recycleDecodeBuffers(original, decoded []byte) {
+	r.recycleDecodedFrameBuffer(decoded)
+	if !sameSliceData(original, decoded) {
+		r.recycleDecodedFrameBuffer(original)
+	}
 }
 
 func (r *Reader) read(dst []byte, off int64) (int64, int, error) {
@@ -257,58 +303,75 @@ func (r *Reader) read(dst []byte, off int64) (int64, int, error) {
 			off, int64(index.DecompressedOffset), int64(index.DecompressedOffset)+int64(index.DecompressedSize))
 	}
 
-	var decompressed []byte
-
-	cachedData, ok := r.frameCache.Get(index.ID)
-	if ok {
-		decompressed = cachedData
-	} else {
-		if index.CompressedSize > maxDecoderFrameSize {
-			return 0, 0, fmt.Errorf("index.CompressedSize is too big: %d > %d",
-				index.CompressedSize, maxDecoderFrameSize)
-		}
-
-		src, err := r.env.GetFrameByIndex(index)
-		if err != nil {
-			return 0, 0, fmt.Errorf("failed to read compressed data at: %d, %w", index.CompressedOffset, err)
-		}
-
-		if len(src) != int(index.CompressedSize) {
-			return 0, 0, fmt.Errorf("compressed size does not match index at: %d: expected: %d, index: %+v",
-				off, len(src), index)
-		}
-
-		decompressed, err = r.dec.DecodeAll(src, nil)
-		if err != nil {
-			return 0, 0, fmt.Errorf("failed to decompress data data at: %d, %w", index.CompressedOffset, err)
-		}
-
-		if r.table.HasChecksums() {
-			checksum := uint32(xxhash.Sum64(decompressed))
-			if index.Checksum != checksum {
-				return 0, 0, fmt.Errorf("checksum verification failed at: %d: expected: %d, actual: %d",
-					index.CompressedOffset, index.Checksum, checksum)
-			}
-		}
-		r.frameCache.Put(index.ID, decompressed)
-	}
-
-	if len(decompressed) != int(index.DecompressedSize) {
-		return 0, 0, fmt.Errorf("index corruption: len: %d, expected: %d", len(decompressed), int(index.DecompressedSize))
-	}
-
 	offsetWithinFrame := uint64(off) - index.DecompressedOffset
 
-	size := uint64(len(decompressed)) - offsetWithinFrame
+	size := uint64(index.DecompressedSize) - offsetWithinFrame
 	if size > uint64(len(dst)) {
 		size = uint64(len(dst))
 	}
 
+	if n, ok, valid := r.frameCache.Copy(index.ID, dst, offsetWithinFrame, size, int(index.DecompressedSize)); ok {
+		if !valid {
+			return 0, 0, fmt.Errorf("index corruption: len: %d, expected: %d", n, int(index.DecompressedSize))
+		}
+		r.logger.Debug("decompressed", slog.Uint64("offsetWithinFrame", offsetWithinFrame), slog.Uint64("end", offsetWithinFrame+size),
+			slog.Uint64("size", size), slog.Int("lenDecompressed", int(index.DecompressedSize)), slog.Int("lenDst", len(dst)), slog.Any("index", index))
+		return off + int64(n), n, nil
+	}
+
+	var decompressed []byte
+
+	if index.CompressedSize > maxDecoderFrameSize {
+		return 0, 0, fmt.Errorf("index.CompressedSize is too big: %d > %d",
+			index.CompressedSize, maxDecoderFrameSize)
+	}
+
+	src, err := r.env.GetFrameByIndex(index)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to read compressed data at: %d, %w", index.CompressedOffset, err)
+	}
+
+	if len(src) != int(index.CompressedSize) {
+		return 0, 0, fmt.Errorf("compressed size does not match index at: %d: expected: %d, index: %+v",
+			off, len(src), index)
+	}
+
+	decodeDst := r.decodedFrameBuffer(int(index.DecompressedSize))
+	decompressed, err = r.dec.DecodeAll(src, decodeDst)
+	if err != nil {
+		r.recycleDecodedFrameBuffer(decodeDst)
+		return 0, 0, fmt.Errorf("failed to decompress data data at: %d, %w", index.CompressedOffset, err)
+	}
+
+	if len(decompressed) != int(index.DecompressedSize) {
+		r.recycleDecodeBuffers(decodeDst, decompressed)
+		return 0, 0, fmt.Errorf("index corruption: len: %d, expected: %d", len(decompressed), int(index.DecompressedSize))
+	}
+
+	if r.table.HasChecksums() {
+		checksum := uint32(xxhash.Sum64(decompressed))
+		if index.Checksum != checksum {
+			r.recycleDecodeBuffers(decodeDst, decompressed)
+			return 0, 0, fmt.Errorf("checksum verification failed at: %d: expected: %d, actual: %d",
+				index.CompressedOffset, index.Checksum, checksum)
+		}
+	}
+
+	n := copy(dst, decompressed[offsetWithinFrame:offsetWithinFrame+size])
+	evicted, stored := r.frameCache.Put(index.ID, decompressed)
+	if evicted != nil {
+		r.recycleDecodedFrameBuffer(evicted)
+	}
+	if !stored {
+		r.recycleDecodeBuffers(decodeDst, decompressed)
+	} else if !sameSliceData(decodeDst, decompressed) {
+		r.recycleDecodedFrameBuffer(decodeDst)
+	}
+
 	r.logger.Debug("decompressed", slog.Uint64("offsetWithinFrame", offsetWithinFrame), slog.Uint64("end", offsetWithinFrame+size),
 		slog.Uint64("size", size), slog.Int("lenDecompressed", len(decompressed)), slog.Int("lenDst", len(dst)), slog.Any("index", index))
-	copy(dst, decompressed[offsetWithinFrame:offsetWithinFrame+size])
 
-	return off + int64(size), int(size), nil
+	return off + int64(n), n, nil
 }
 
 // Seek updates the Reader's current offset and returns the new offset.

--- a/pkg/reader_cache.go
+++ b/pkg/reader_cache.go
@@ -11,6 +11,10 @@ type readerFrameCache struct {
 	cache framecache.Cache
 }
 
+type evictingFrameCache interface {
+	PutWithEvicted(frameID int64, data []byte) ([]byte, bool)
+}
+
 func defaultFrameCache() framecache.Cache {
 	return framecache.NewFIFO(framecache.Limits{MaxFrames: 1})
 }
@@ -29,11 +33,29 @@ func (c *readerFrameCache) Get(frameID int64) ([]byte, bool) {
 	return c.cache.Get(frameID)
 }
 
-func (c *readerFrameCache) Put(frameID int64, data []byte) {
+func (c *readerFrameCache) Copy(frameID int64, dst []byte, offset, size uint64, expectedLen int) (int, bool, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	data, ok := c.cache.Get(frameID)
+	if !ok {
+		return 0, false, true
+	}
+	if len(data) != expectedLen {
+		return len(data), true, false
+	}
+	return copy(dst, data[offset:offset+size]), true, true
+}
+
+func (c *readerFrameCache) Put(frameID int64, data []byte) ([]byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if cache, ok := c.cache.(evictingFrameCache); ok {
+		return cache.PutWithEvicted(frameID, data)
+	}
 	c.cache.Put(frameID, data)
+	return nil, true
 }
 
 func (c *readerFrameCache) Clear() {

--- a/pkg/reader_cache_benchmark_test.go
+++ b/pkg/reader_cache_benchmark_test.go
@@ -31,6 +31,14 @@ func (c *benchmarkCountingCache) Put(frameID int64, data []byte) {
 	c.cache.Put(frameID, data)
 }
 
+func (c *benchmarkCountingCache) PutWithEvicted(frameID int64, data []byte) ([]byte, bool) {
+	if cache, ok := c.cache.(evictingFrameCache); ok {
+		return cache.PutWithEvicted(frameID, data)
+	}
+	c.cache.Put(frameID, data)
+	return nil, true
+}
+
 func (c *benchmarkCountingCache) Clear() {
 	c.cache.Clear()
 }


### PR DESCRIPTION
## Summary

This lets `Reader` reuse decoded-frame output buffers on cache misses. Instead of always calling `DecodeAll(src, nil)`, the reader supplies a reusable destination buffer sized for the frame's decompressed size.

Cache hits now copy while holding the reader cache wrapper lock. Built-in caches also expose an optional evicted-buffer return path so the reader can recycle decoded buffers that leave the cache.

## Public API

The `framecache.Cache` interface is unchanged. Existing custom caches continue to work. The reader uses the optional eviction-return method only when a cache implementation provides it.

## Ownership And Concurrency

The cache still stores decompressed frames as immutable slices. Copying cache hits under the reader cache lock ensures a cached slice is not read concurrently with eviction and recycling.

The decoded-buffer recycler is Reader-owned and bounded.

## Correctness Notes

This keeps the Reader-owned cache model: buffers are recycled only after they are no longer stored in the cache or after a failed decode/checksum path. Concurrent `ReadAt` safety still depends on the caller-provided decoder and read environment, with cache synchronization handled by Reader.

## Benchmarks

A standalone reader-cache benchmark run showed the miss-heavy uniform FIFO case moving from roughly `464 B/op, 10 allocs/op` to roughly `432 B/op, 9 allocs/op`. The remaining allocations on this branch come from independent logging, compressed-buffer, and cache-entry sources.

## Tests

`go test ./...`

`go test -race -run 'TestReader.*FrameCache|TestReaderNoStorageFrameCache' ./...`

`go test -run '^$' -bench '^BenchmarkReaderFrameCache' -benchmem`