### PR TITLE
pkg: use intrusive frame cache lists

### DIFF
--- a/pkg/framecache/cache_test.go
+++ b/pkg/framecache/cache_test.go
@@ -2,7 +2,6 @@ package framecache
 
 import (
 	"bytes"
-	"container/list"
 	"testing"
 )
 
@@ -205,7 +204,7 @@ func TestSieveReplacementPreservesPositionAndHand(t *testing.T) {
 	if c.hand != hand {
 		t.Fatal("replacement moved hand")
 	}
-	entry := elem.Value.(*sieveEntry)
+	entry := elem
 	if entry.count != 1 {
 		t.Fatalf("replacement counter = %d, want 1", entry.count)
 	}
@@ -259,86 +258,104 @@ func assertCacheInvariants(t *testing.T, c Cache, context string) {
 		t.Fatalf(format, args...)
 	}
 
-	var (
-		order  *list.List
-		items  map[int64]*list.Element
-		bytes  uint64
-		hand   *list.Element
-		limits Limits
-	)
+	var count int
+	var sum uint64
+	var bytes uint64
+	var limits Limits
 
 	switch v := c.(type) {
 	case *FIFO:
-		order = &v.order
-		items = v.items
+		count, sum = walkCacheEntries(fail, v.items, &v.order, nil, fifoEntryInfo)
 		bytes = v.bytes
 		limits = v.limits
 	case *LRU:
-		order = &v.order
-		items = v.items
+		count, sum = walkCacheEntries(fail, v.items, &v.order, nil, lruEntryInfo)
 		bytes = v.bytes
 		limits = v.limits
 	case *Sieve:
-		order = &v.order
-		items = v.items
+		count, sum = walkCacheEntries(fail, v.items, &v.order, v.hand, sieveEntryInfo)
 		bytes = v.bytes
-		hand = v.hand
 		limits = v.limits
 	default:
 		fail("unsupported cache type %T", c)
 	}
 
-	if len(items) != order.Len() {
-		fail("map length = %d, list length = %d", len(items), order.Len())
+	if limits.MaxFrames <= 0 && count != 0 {
+		fail("disabled cache holds %d frames", count)
 	}
-	if limits.MaxFrames <= 0 && order.Len() != 0 {
-		fail("disabled cache holds %d frames", order.Len())
-	}
-	if limits.MaxFrames > 0 && order.Len() > limits.MaxFrames {
-		fail("cache holds %d frames, limit is %d", order.Len(), limits.MaxFrames)
+	if limits.MaxFrames > 0 && count > limits.MaxFrames {
+		fail("cache holds %d frames, limit is %d", count, limits.MaxFrames)
 	}
 	if limits.MaxBytes > 0 && bytes > limits.MaxBytes {
 		fail("cache holds %d bytes, limit is %d", bytes, limits.MaxBytes)
-	}
-	if order.Len() == 0 && hand != nil {
-		fail("empty Sieve cache has non-nil hand")
-	}
-
-	var sum uint64
-	seen := make(map[int64]bool, order.Len())
-	for elem := order.Front(); elem != nil; elem = elem.Next() {
-		frameID, data := cacheElement(t, elem, context)
-		if seen[frameID] {
-			fail("duplicate frame ID %d", frameID)
-		}
-		seen[frameID] = true
-		if items[frameID] != elem {
-			fail("map element mismatch for frame ID %d", frameID)
-		}
-		sum += uint64(len(data))
 	}
 	if sum != bytes {
 		fail("byte accounting = %d, want %d", bytes, sum)
 	}
 }
 
-func cacheElement(t *testing.T, elem *list.Element, context string) (int64, []byte) {
-	t.Helper()
+type cacheEntryInfo struct {
+	frameID int64
+	data    []byte
+}
 
-	switch entry := elem.Value.(type) {
-	case *fifoEntry:
-		return entry.frameID, entry.data
-	case *lruEntry:
-		return entry.frameID, entry.data
-	case *sieveEntry:
-		return entry.frameID, entry.data
-	default:
-		if context != "" {
-			t.Fatalf("list entry has type %T (%s)", elem.Value, context)
+func fifoEntryInfo(entry *fifoEntry) cacheEntryInfo {
+	return cacheEntryInfo{frameID: entry.frameID, data: entry.data}
+}
+
+func lruEntryInfo(entry *lruEntry) cacheEntryInfo {
+	return cacheEntryInfo{frameID: entry.frameID, data: entry.data}
+}
+
+func sieveEntryInfo(entry *sieveEntry) cacheEntryInfo {
+	return cacheEntryInfo{frameID: entry.frameID, data: entry.data}
+}
+
+func walkCacheEntries[T intrusiveListEntry[T]](
+	fail func(string, ...any),
+	items map[int64]T,
+	order *intrusiveList[T],
+	hand T,
+	info func(T) cacheEntryInfo,
+) (int, uint64) {
+	seen := make(map[int64]bool, len(items))
+	var zero T
+	handSeen := hand == zero
+	var count int
+	var sum uint64
+	var prev T
+	for entry := order.Front(); entry != zero; entry = entry.links().next {
+		entryInfo := info(entry)
+		if entry.links().prev != prev {
+			fail("broken prev link for frame ID %d", entryInfo.frameID)
 		}
-		t.Fatalf("list entry has type %T", elem.Value)
-		return 0, nil
+		if seen[entryInfo.frameID] {
+			fail("duplicate frame ID %d", entryInfo.frameID)
+		}
+		seen[entryInfo.frameID] = true
+		if items[entryInfo.frameID] != entry {
+			fail("map element mismatch for frame ID %d", entryInfo.frameID)
+		}
+		if entry == hand {
+			handSeen = true
+		}
+		count++
+		sum += uint64(len(entryInfo.data))
+		prev = entry
 	}
+	if count != len(items) {
+		fail("map length = %d, list length = %d", len(items), count)
+	}
+	if count != order.Len() {
+		fail("list length field = %d, walked %d", order.Len(), count)
+	}
+	if prev != order.Back() {
+		fail("tail mismatch")
+	}
+	if !handSeen {
+		fail("Sieve hand is not in cache")
+	}
+	return count, sum
 }
 
 func cacheByStrategy(strategy uint8, limits Limits) (string, Cache) {

--- a/pkg/framecache/fifo.go
+++ b/pkg/framecache/fifo.go
@@ -1,37 +1,40 @@
 package framecache
 
-import "container/list"
-
 // FIFO is a decoded-frame cache using first-in, first-out replacement.
 //
 // Calls to Get do not affect eviction order.
 type FIFO struct {
 	limits Limits
-	items  map[int64]*list.Element
-	order  list.List
+	items  map[int64]*fifoEntry
+	order  intrusiveList[*fifoEntry]
 	bytes  uint64
 }
 
 type fifoEntry struct {
 	frameID int64
 	data    []byte
+	list    intrusiveLinks[*fifoEntry]
+}
+
+func (entry *fifoEntry) links() *intrusiveLinks[*fifoEntry] {
+	return &entry.list
 }
 
 // NewFIFO returns a FIFO cache with the provided limits.
 func NewFIFO(limits Limits) *FIFO {
 	return &FIFO{
 		limits: limits,
-		items:  make(map[int64]*list.Element),
+		items:  make(map[int64]*fifoEntry),
 	}
 }
 
 // Get returns the frame stored for frameID, if any.
 func (c *FIFO) Get(frameID int64) ([]byte, bool) {
-	elem, ok := c.items[frameID]
+	entry, ok := c.items[frameID]
 	if !ok {
 		return nil, false
 	}
-	return elem.Value.(*fifoEntry).data, true
+	return entry.data, true
 }
 
 // Put stores data for frameID as a new FIFO insertion, replacing any existing
@@ -43,13 +46,14 @@ func (c *FIFO) Put(frameID int64, data []byte) {
 		return
 	}
 
-	if elem, ok := c.items[frameID]; ok {
-		c.removeElement(elem)
+	if entry, ok := c.items[frameID]; ok {
+		c.removeElement(entry)
 	}
 
 	c.evictFor(1, size)
 	entry := &fifoEntry{frameID: frameID, data: data}
-	c.items[frameID] = c.order.PushBack(entry)
+	c.order.PushBack(entry)
+	c.items[frameID] = entry
 	c.bytes += uint64(len(entry.data))
 }
 
@@ -61,26 +65,25 @@ func (c *FIFO) Clear() {
 }
 
 func (c *FIFO) remove(frameID int64) {
-	elem, ok := c.items[frameID]
+	entry, ok := c.items[frameID]
 	if !ok {
 		return
 	}
-	c.removeElement(elem)
+	c.removeElement(entry)
 }
 
-func (c *FIFO) removeElement(elem *list.Element) {
-	entry := elem.Value.(*fifoEntry)
+func (c *FIFO) removeElement(entry *fifoEntry) {
 	delete(c.items, entry.frameID)
 	c.bytes -= uint64(len(entry.data))
-	c.order.Remove(elem)
+	c.order.Remove(entry)
 }
 
 func (c *FIFO) evictFor(extraFrames int, extraBytes uint64) {
 	for c.limits.overLimits(c.order.Len()+extraFrames, c.bytes+extraBytes) {
-		elem := c.order.Front()
-		if elem == nil {
+		entry := c.order.Front()
+		if entry == nil {
 			return
 		}
-		c.removeElement(elem)
+		c.removeElement(entry)
 	}
 }

--- a/pkg/framecache/fifo.go
+++ b/pkg/framecache/fifo.go
@@ -13,11 +13,7 @@ type FIFO struct {
 type fifoEntry struct {
 	frameID int64
 	data    []byte
-	list    intrusiveLinks[*fifoEntry]
-}
-
-func (entry *fifoEntry) links() *intrusiveLinks[*fifoEntry] {
-	return &entry.list
+	intrusiveLinks[*fifoEntry]
 }
 
 // NewFIFO returns a FIFO cache with the provided limits.

--- a/pkg/framecache/fifo.go
+++ b/pkg/framecache/fifo.go
@@ -48,8 +48,7 @@ func (c *FIFO) Put(frameID int64, data []byte) {
 
 	c.evictFor(1, size)
 	entry := &fifoEntry{frameID: frameID, data: data}
-	c.order.PushBack(entry)
-	c.items[frameID] = entry
+	c.items[frameID] = c.order.PushBack(entry)
 	c.bytes += uint64(len(entry.data))
 }
 

--- a/pkg/framecache/fifo.go
+++ b/pkg/framecache/fifo.go
@@ -11,9 +11,9 @@ type FIFO struct {
 }
 
 type fifoEntry struct {
-	frameID int64
-	data    []byte
-	intrusiveLinks[*fifoEntry]
+	frameID                    int64
+	data                       []byte
+	intrusiveLinks[*fifoEntry] //nolint:unused // Used through method promotion by intrusiveList.
 }
 
 // NewFIFO returns a FIFO cache with the provided limits.

--- a/pkg/framecache/intrusive_list.go
+++ b/pkg/framecache/intrusive_list.go
@@ -10,6 +10,10 @@ type intrusiveLinks[T any] struct {
 	next T
 }
 
+func (links *intrusiveLinks[T]) links() *intrusiveLinks[T] {
+	return links
+}
+
 type intrusiveList[T intrusiveListEntry[T]] struct {
 	head T
 	tail T

--- a/pkg/framecache/intrusive_list.go
+++ b/pkg/framecache/intrusive_list.go
@@ -36,7 +36,7 @@ func (l *intrusiveList[T]) Back() T {
 	return l.tail
 }
 
-func (l *intrusiveList[T]) PushFront(entry T) {
+func (l *intrusiveList[T]) PushFront(entry T) T {
 	var zero T
 
 	entryLinks := entry.links()
@@ -50,9 +50,10 @@ func (l *intrusiveList[T]) PushFront(entry T) {
 	}
 	l.head = entry
 	l.len++
+	return entry
 }
 
-func (l *intrusiveList[T]) PushBack(entry T) {
+func (l *intrusiveList[T]) PushBack(entry T) T {
 	var zero T
 
 	entryLinks := entry.links()
@@ -66,6 +67,7 @@ func (l *intrusiveList[T]) PushBack(entry T) {
 	}
 	l.tail = entry
 	l.len++
+	return entry
 }
 
 func (l *intrusiveList[T]) Remove(entry T) {

--- a/pkg/framecache/intrusive_list.go
+++ b/pkg/framecache/intrusive_list.go
@@ -10,6 +10,7 @@ type intrusiveLinks[T any] struct {
 	next T
 }
 
+//nolint:unused // Used through method promotion from embedded intrusiveLinks fields.
 func (links *intrusiveLinks[T]) links() *intrusiveLinks[T] {
 	return links
 }

--- a/pkg/framecache/intrusive_list.go
+++ b/pkg/framecache/intrusive_list.go
@@ -1,0 +1,104 @@
+package framecache
+
+type intrusiveListEntry[T any] interface {
+	comparable
+	links() *intrusiveLinks[T]
+}
+
+type intrusiveLinks[T any] struct {
+	prev T
+	next T
+}
+
+type intrusiveList[T intrusiveListEntry[T]] struct {
+	head T
+	tail T
+	len  int
+}
+
+func (l *intrusiveList[T]) Init() {
+	*l = intrusiveList[T]{}
+}
+
+func (l *intrusiveList[T]) Len() int {
+	return l.len
+}
+
+func (l *intrusiveList[T]) Front() T {
+	return l.head
+}
+
+func (l *intrusiveList[T]) Back() T {
+	return l.tail
+}
+
+func (l *intrusiveList[T]) PushFront(entry T) {
+	var zero T
+
+	entryLinks := entry.links()
+	entryLinks.prev = zero
+	entryLinks.next = l.head
+
+	if l.head != zero {
+		l.head.links().prev = entry
+	} else {
+		l.tail = entry
+	}
+	l.head = entry
+	l.len++
+}
+
+func (l *intrusiveList[T]) PushBack(entry T) {
+	var zero T
+
+	entryLinks := entry.links()
+	entryLinks.prev = l.tail
+	entryLinks.next = zero
+
+	if l.tail != zero {
+		l.tail.links().next = entry
+	} else {
+		l.head = entry
+	}
+	l.tail = entry
+	l.len++
+}
+
+func (l *intrusiveList[T]) Remove(entry T) {
+	var zero T
+
+	entryLinks := entry.links()
+	if entryLinks.prev != zero {
+		entryLinks.prev.links().next = entryLinks.next
+	} else {
+		l.head = entryLinks.next
+	}
+	if entryLinks.next != zero {
+		entryLinks.next.links().prev = entryLinks.prev
+	} else {
+		l.tail = entryLinks.prev
+	}
+	entryLinks.prev = zero
+	entryLinks.next = zero
+	l.len--
+}
+
+func (l *intrusiveList[T]) MoveToFront(entry T) {
+	if l.head == entry {
+		return
+	}
+	l.Remove(entry)
+	l.PushFront(entry)
+}
+
+func (l *intrusiveList[T]) PrevCircular(entry T) T {
+	var zero T
+
+	if l.len <= 1 {
+		return zero
+	}
+	if prev := entry.links().prev; prev != zero {
+		return prev
+	}
+	return l.tail
+}

--- a/pkg/framecache/intrusive_list_test.go
+++ b/pkg/framecache/intrusive_list_test.go
@@ -7,12 +7,8 @@ import (
 )
 
 type intrusiveListTestEntry struct {
-	id   int
-	list intrusiveLinks[*intrusiveListTestEntry]
-}
-
-func (entry *intrusiveListTestEntry) links() *intrusiveLinks[*intrusiveListTestEntry] {
-	return &entry.list
+	id int
+	intrusiveLinks[*intrusiveListTestEntry]
 }
 
 func TestIntrusiveListInit(t *testing.T) {
@@ -226,13 +222,13 @@ func assertIntrusiveListMatchesContainer(
 			t.Fatalf("entry %d = %s, want %s",
 				index, intrusiveListEntryName(gotEntry), intrusiveListEntryName(listElementEntry(wantElem)))
 		}
-		if gotEntry.list.prev != prev {
+		if gotEntry.prev != prev {
 			t.Fatalf("entry %d prev = %s, want %s",
-				gotEntry.id, intrusiveListEntryName(gotEntry.list.prev), intrusiveListEntryName(prev))
+				gotEntry.id, intrusiveListEntryName(gotEntry.prev), intrusiveListEntryName(prev))
 		}
 
 		prev = gotEntry
-		gotEntry = gotEntry.list.next
+		gotEntry = gotEntry.next
 	}
 	if gotEntry != nil {
 		t.Fatalf("list has trailing entry %s", intrusiveListEntryName(gotEntry))
@@ -250,9 +246,9 @@ func assertRemovedIntrusiveListEntriesDetached(
 		if elements[i] != nil {
 			continue
 		}
-		if entry.list.prev != nil || entry.list.next != nil {
+		if entry.prev != nil || entry.next != nil {
 			t.Fatalf("entry %d links = prev %s next %s, want detached",
-				entry.id, intrusiveListEntryName(entry.list.prev), intrusiveListEntryName(entry.list.next))
+				entry.id, intrusiveListEntryName(entry.prev), intrusiveListEntryName(entry.next))
 		}
 	}
 }

--- a/pkg/framecache/intrusive_list_test.go
+++ b/pkg/framecache/intrusive_list_test.go
@@ -1,0 +1,346 @@
+package framecache
+
+import (
+	"container/list"
+	"strconv"
+	"testing"
+)
+
+type intrusiveListTestEntry struct {
+	id   int
+	list intrusiveLinks[*intrusiveListTestEntry]
+}
+
+func (entry *intrusiveListTestEntry) links() *intrusiveLinks[*intrusiveListTestEntry] {
+	return &entry.list
+}
+
+func TestIntrusiveListPush(t *testing.T) {
+	entries := newIntrusiveListTestEntries(3)
+	var list intrusiveList[*intrusiveListTestEntry]
+
+	assertIntrusiveList(t, &list)
+
+	list.PushBack(entries[0])
+	assertIntrusiveList(t, &list, entries[0])
+
+	list.PushBack(entries[1])
+	assertIntrusiveList(t, &list, entries[0], entries[1])
+
+	list.PushFront(entries[2])
+	assertIntrusiveList(t, &list, entries[2], entries[0], entries[1])
+}
+
+func TestIntrusiveListRemove(t *testing.T) {
+	entries := newIntrusiveListTestEntries(4)
+	var list intrusiveList[*intrusiveListTestEntry]
+	for _, entry := range entries {
+		list.PushBack(entry)
+	}
+
+	list.Remove(entries[1])
+	assertDetachedIntrusiveListEntry(t, entries[1])
+	assertIntrusiveList(t, &list, entries[0], entries[2], entries[3])
+
+	list.Remove(entries[0])
+	assertDetachedIntrusiveListEntry(t, entries[0])
+	assertIntrusiveList(t, &list, entries[2], entries[3])
+
+	list.Remove(entries[3])
+	assertDetachedIntrusiveListEntry(t, entries[3])
+	assertIntrusiveList(t, &list, entries[2])
+
+	list.Remove(entries[2])
+	assertDetachedIntrusiveListEntry(t, entries[2])
+	assertIntrusiveList(t, &list)
+}
+
+func TestIntrusiveListMoveToFront(t *testing.T) {
+	entries := newIntrusiveListTestEntries(4)
+	var list intrusiveList[*intrusiveListTestEntry]
+	for _, entry := range entries {
+		list.PushBack(entry)
+	}
+
+	list.MoveToFront(entries[2])
+	assertIntrusiveList(t, &list, entries[2], entries[0], entries[1], entries[3])
+
+	list.MoveToFront(entries[3])
+	assertIntrusiveList(t, &list, entries[3], entries[2], entries[0], entries[1])
+
+	list.MoveToFront(entries[3])
+	assertIntrusiveList(t, &list, entries[3], entries[2], entries[0], entries[1])
+}
+
+func TestIntrusiveListPrevCircular(t *testing.T) {
+	entries := newIntrusiveListTestEntries(3)
+	var list intrusiveList[*intrusiveListTestEntry]
+
+	list.PushBack(entries[0])
+	if got := list.PrevCircular(entries[0]); got != nil {
+		t.Fatalf("PrevCircular(single entry) = %s, want nil", intrusiveListEntryName(got))
+	}
+
+	list.PushBack(entries[1])
+	list.PushBack(entries[2])
+
+	assertPrevCircular(t, &list, entries[0], entries[2])
+	assertPrevCircular(t, &list, entries[1], entries[0])
+	assertPrevCircular(t, &list, entries[2], entries[1])
+}
+
+func TestIntrusiveListInit(t *testing.T) {
+	entries := newIntrusiveListTestEntries(2)
+	var list intrusiveList[*intrusiveListTestEntry]
+	list.PushBack(entries[0])
+	list.PushBack(entries[1])
+
+	list.Init()
+
+	assertIntrusiveList(t, &list)
+}
+
+func FuzzIntrusiveListOperations(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{
+		intrusiveListOp(opPushBack, 0),
+		intrusiveListOp(opPushBack, 1),
+		intrusiveListOp(opPushBack, 2),
+	})
+	f.Add([]byte{
+		intrusiveListOp(opPushFront, 0),
+		intrusiveListOp(opPushFront, 1),
+		intrusiveListOp(opPushFront, 2),
+	})
+	f.Add([]byte{
+		intrusiveListOp(opPushBack, 0),
+		intrusiveListOp(opPushBack, 1),
+		intrusiveListOp(opRemove, 1),
+		intrusiveListOp(opRemove, 0),
+	})
+	f.Add([]byte{
+		intrusiveListOp(opPushBack, 0),
+		intrusiveListOp(opPushBack, 1),
+		intrusiveListOp(opMoveToFront, 1),
+		intrusiveListOp(opRemoveFront, 0),
+	})
+
+	f.Fuzz(func(t *testing.T, rawOps []byte) {
+		const entryCount = 16
+		if len(rawOps) > 512 {
+			rawOps = rawOps[:512]
+		}
+
+		entries := newIntrusiveListTestEntries(entryCount)
+		elements := make([]*list.Element, entryCount)
+		var got intrusiveList[*intrusiveListTestEntry]
+		var want list.List
+
+		for opIndex, rawOp := range rawOps {
+			op, entryIndex := decodeIntrusiveListOp(rawOp, entryCount)
+			entry := entries[entryIndex]
+			elem := elements[entryIndex]
+
+			switch op {
+			case opPushFront:
+				if elem == nil {
+					got.PushFront(entry)
+					elements[entryIndex] = want.PushFront(entry)
+				}
+			case opPushBack:
+				if elem == nil {
+					got.PushBack(entry)
+					elements[entryIndex] = want.PushBack(entry)
+				}
+			case opRemove:
+				if elem != nil {
+					got.Remove(entry)
+					want.Remove(elem)
+					elements[entryIndex] = nil
+				}
+			case opMoveToFront:
+				if elem != nil {
+					got.MoveToFront(entry)
+					want.MoveToFront(elem)
+				}
+			case opRemoveFront:
+				gotFront := got.Front()
+				wantFront := listElementEntry(want.Front())
+				if gotFront != wantFront {
+					t.Fatalf("op %d: Front() before Remove = %s, want %s",
+						opIndex, intrusiveListEntryName(gotFront), intrusiveListEntryName(wantFront))
+				}
+				if gotFront != nil {
+					got.Remove(gotFront)
+					want.Remove(want.Front())
+					elements[gotFront.id] = nil
+				}
+			case opCheckPrevCircular:
+				if elem != nil {
+					gotPrev := got.PrevCircular(entry)
+					wantPrev := prevCircularListElement(&want, elem)
+					if gotPrev != wantPrev {
+						t.Fatalf("op %d: PrevCircular(%d) = %s, want %s",
+							opIndex, entry.id, intrusiveListEntryName(gotPrev), intrusiveListEntryName(wantPrev))
+					}
+				}
+			}
+
+			assertIntrusiveListMatchesContainer(t, &got, &want)
+			assertDetachedIntrusiveListEntries(t, entries, elements)
+		}
+	})
+}
+
+const (
+	opPushFront byte = iota
+	opPushBack
+	opRemove
+	opMoveToFront
+	opRemoveFront
+	opCheckPrevCircular
+)
+
+func intrusiveListOp(op byte, entryIndex int) byte {
+	return op&0x07 | byte(entryIndex<<3)
+}
+
+func decodeIntrusiveListOp(rawOp byte, entryCount int) (byte, int) {
+	return rawOp & 0x07, int(rawOp>>3) % entryCount
+}
+
+func newIntrusiveListTestEntries(n int) []*intrusiveListTestEntry {
+	entries := make([]*intrusiveListTestEntry, n)
+	for i := range entries {
+		entries[i] = &intrusiveListTestEntry{id: i}
+	}
+	return entries
+}
+
+func assertIntrusiveList(
+	t *testing.T,
+	list *intrusiveList[*intrusiveListTestEntry],
+	want ...*intrusiveListTestEntry,
+) {
+	t.Helper()
+
+	if got := list.Len(); got != len(want) {
+		t.Fatalf("Len() = %d, want %d", got, len(want))
+	}
+	if got, want := list.Front(), firstIntrusiveListEntry(want); got != want {
+		t.Fatalf("Front() = %s, want %s", intrusiveListEntryName(got), intrusiveListEntryName(want))
+	}
+	if got, want := list.Back(), lastIntrusiveListEntry(want); got != want {
+		t.Fatalf("Back() = %s, want %s", intrusiveListEntryName(got), intrusiveListEntryName(want))
+	}
+
+	var prev *intrusiveListTestEntry
+	count := 0
+	for entry := list.Front(); entry != nil; entry = entry.list.next {
+		if count >= len(want) {
+			t.Fatalf("list has more than %d entries or contains a cycle", len(want))
+		}
+		if entry != want[count] {
+			t.Fatalf("entry %d = %s, want %s",
+				count, intrusiveListEntryName(entry), intrusiveListEntryName(want[count]))
+		}
+		if entry.list.prev != prev {
+			t.Fatalf("entry %d prev = %s, want %s",
+				entry.id, intrusiveListEntryName(entry.list.prev), intrusiveListEntryName(prev))
+		}
+		prev = entry
+		count++
+	}
+	if count != len(want) {
+		t.Fatalf("walked %d entries, want %d", count, len(want))
+	}
+}
+
+func assertPrevCircular(
+	t *testing.T,
+	list *intrusiveList[*intrusiveListTestEntry],
+	entry *intrusiveListTestEntry,
+	want *intrusiveListTestEntry,
+) {
+	t.Helper()
+
+	if got := list.PrevCircular(entry); got != want {
+		t.Fatalf("PrevCircular(%d) = %s, want %s",
+			entry.id, intrusiveListEntryName(got), intrusiveListEntryName(want))
+	}
+}
+
+func assertDetachedIntrusiveListEntries(
+	t *testing.T,
+	entries []*intrusiveListTestEntry,
+	elements []*list.Element,
+) {
+	t.Helper()
+
+	for i, entry := range entries {
+		if elements[i] == nil {
+			assertDetachedIntrusiveListEntry(t, entry)
+		}
+	}
+}
+
+func assertDetachedIntrusiveListEntry(t *testing.T, entry *intrusiveListTestEntry) {
+	t.Helper()
+
+	if entry.list.prev != nil || entry.list.next != nil {
+		t.Fatalf("entry %d links = prev %s next %s, want detached",
+			entry.id, intrusiveListEntryName(entry.list.prev), intrusiveListEntryName(entry.list.next))
+	}
+}
+
+func assertIntrusiveListMatchesContainer(
+	t *testing.T,
+	got *intrusiveList[*intrusiveListTestEntry],
+	want *list.List,
+) {
+	t.Helper()
+
+	entries := make([]*intrusiveListTestEntry, 0, want.Len())
+	for elem := want.Front(); elem != nil; elem = elem.Next() {
+		entries = append(entries, elem.Value.(*intrusiveListTestEntry))
+	}
+	assertIntrusiveList(t, got, entries...)
+}
+
+func prevCircularListElement(l *list.List, elem *list.Element) *intrusiveListTestEntry {
+	if l.Len() <= 1 {
+		return nil
+	}
+	if prev := elem.Prev(); prev != nil {
+		return prev.Value.(*intrusiveListTestEntry)
+	}
+	return listElementEntry(l.Back())
+}
+
+func listElementEntry(elem *list.Element) *intrusiveListTestEntry {
+	if elem == nil {
+		return nil
+	}
+	return elem.Value.(*intrusiveListTestEntry)
+}
+
+func firstIntrusiveListEntry(entries []*intrusiveListTestEntry) *intrusiveListTestEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	return entries[0]
+}
+
+func lastIntrusiveListEntry(entries []*intrusiveListTestEntry) *intrusiveListTestEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	return entries[len(entries)-1]
+}
+
+func intrusiveListEntryName(entry *intrusiveListTestEntry) string {
+	if entry == nil {
+		return "nil"
+	}
+	return strconv.Itoa(entry.id)
+}

--- a/pkg/framecache/intrusive_list_test.go
+++ b/pkg/framecache/intrusive_list_test.go
@@ -15,185 +15,59 @@ func (entry *intrusiveListTestEntry) links() *intrusiveLinks[*intrusiveListTestE
 	return &entry.list
 }
 
-func TestIntrusiveListPush(t *testing.T) {
-	entries := newIntrusiveListTestEntries(3)
-	var list intrusiveList[*intrusiveListTestEntry]
-
-	assertIntrusiveList(t, &list)
-
-	list.PushBack(entries[0])
-	assertIntrusiveList(t, &list, entries[0])
-
-	list.PushBack(entries[1])
-	assertIntrusiveList(t, &list, entries[0], entries[1])
-
-	list.PushFront(entries[2])
-	assertIntrusiveList(t, &list, entries[2], entries[0], entries[1])
-}
-
-func TestIntrusiveListRemove(t *testing.T) {
-	entries := newIntrusiveListTestEntries(4)
-	var list intrusiveList[*intrusiveListTestEntry]
-	for _, entry := range entries {
-		list.PushBack(entry)
-	}
-
-	list.Remove(entries[1])
-	assertDetachedIntrusiveListEntry(t, entries[1])
-	assertIntrusiveList(t, &list, entries[0], entries[2], entries[3])
-
-	list.Remove(entries[0])
-	assertDetachedIntrusiveListEntry(t, entries[0])
-	assertIntrusiveList(t, &list, entries[2], entries[3])
-
-	list.Remove(entries[3])
-	assertDetachedIntrusiveListEntry(t, entries[3])
-	assertIntrusiveList(t, &list, entries[2])
-
-	list.Remove(entries[2])
-	assertDetachedIntrusiveListEntry(t, entries[2])
-	assertIntrusiveList(t, &list)
-}
-
-func TestIntrusiveListMoveToFront(t *testing.T) {
-	entries := newIntrusiveListTestEntries(4)
-	var list intrusiveList[*intrusiveListTestEntry]
-	for _, entry := range entries {
-		list.PushBack(entry)
-	}
-
-	list.MoveToFront(entries[2])
-	assertIntrusiveList(t, &list, entries[2], entries[0], entries[1], entries[3])
-
-	list.MoveToFront(entries[3])
-	assertIntrusiveList(t, &list, entries[3], entries[2], entries[0], entries[1])
-
-	list.MoveToFront(entries[3])
-	assertIntrusiveList(t, &list, entries[3], entries[2], entries[0], entries[1])
-}
-
-func TestIntrusiveListPrevCircular(t *testing.T) {
-	entries := newIntrusiveListTestEntries(3)
-	var list intrusiveList[*intrusiveListTestEntry]
-
-	list.PushBack(entries[0])
-	if got := list.PrevCircular(entries[0]); got != nil {
-		t.Fatalf("PrevCircular(single entry) = %s, want nil", intrusiveListEntryName(got))
-	}
-
-	list.PushBack(entries[1])
-	list.PushBack(entries[2])
-
-	assertPrevCircular(t, &list, entries[0], entries[2])
-	assertPrevCircular(t, &list, entries[1], entries[0])
-	assertPrevCircular(t, &list, entries[2], entries[1])
-}
-
 func TestIntrusiveListInit(t *testing.T) {
 	entries := newIntrusiveListTestEntries(2)
-	var list intrusiveList[*intrusiveListTestEntry]
-	list.PushBack(entries[0])
-	list.PushBack(entries[1])
+	var got intrusiveList[*intrusiveListTestEntry]
+	got.PushBack(entries[0])
+	got.PushBack(entries[1])
 
-	list.Init()
+	got.Init()
 
-	assertIntrusiveList(t, &list)
+	if got.Len() != 0 {
+		t.Fatalf("Len() = %d, want 0", got.Len())
+	}
+	if got.Front() != nil {
+		t.Fatalf("Front() = %s, want nil", intrusiveListEntryName(got.Front()))
+	}
+	if got.Back() != nil {
+		t.Fatalf("Back() = %s, want nil", intrusiveListEntryName(got.Back()))
+	}
 }
 
 func FuzzIntrusiveListOperations(f *testing.F) {
 	f.Add([]byte{})
-	f.Add([]byte{
-		intrusiveListOp(opPushBack, 0),
-		intrusiveListOp(opPushBack, 1),
-		intrusiveListOp(opPushBack, 2),
-	})
-	f.Add([]byte{
-		intrusiveListOp(opPushFront, 0),
-		intrusiveListOp(opPushFront, 1),
-		intrusiveListOp(opPushFront, 2),
-	})
-	f.Add([]byte{
-		intrusiveListOp(opPushBack, 0),
-		intrusiveListOp(opPushBack, 1),
-		intrusiveListOp(opRemove, 1),
-		intrusiveListOp(opRemove, 0),
-	})
-	f.Add([]byte{
-		intrusiveListOp(opPushBack, 0),
-		intrusiveListOp(opPushBack, 1),
-		intrusiveListOp(opMoveToFront, 1),
-		intrusiveListOp(opRemoveFront, 0),
-	})
+	f.Add(encodeIntrusiveListSteps(pushBack(0), pushBack(1), pushBack(2)))
+	f.Add(encodeIntrusiveListSteps(pushFront(0), pushFront(1), pushFront(2)))
+	f.Add(encodeIntrusiveListSteps(pushBack(0), pushBack(1), removeEntry(1), removeEntry(0)))
+	f.Add(encodeIntrusiveListSteps(pushBack(0), pushBack(1), moveToFront(1), removeFront()))
+	f.Add(encodeIntrusiveListSteps(
+		pushBack(0),
+		checkPrevCircular(0),
+		pushBack(1),
+		pushBack(2),
+		checkPrevCircular(0),
+		checkPrevCircular(1),
+		checkPrevCircular(2),
+	))
 
-	f.Fuzz(func(t *testing.T, rawOps []byte) {
+	f.Fuzz(func(t *testing.T, rawSteps []byte) {
 		const entryCount = 16
-		if len(rawOps) > 512 {
-			rawOps = rawOps[:512]
+		if len(rawSteps) > 512 {
+			rawSteps = rawSteps[:512]
 		}
 
-		entries := newIntrusiveListTestEntries(entryCount)
-		elements := make([]*list.Element, entryCount)
-		var got intrusiveList[*intrusiveListTestEntry]
-		var want list.List
-
-		for opIndex, rawOp := range rawOps {
-			op, entryIndex := decodeIntrusiveListOp(rawOp, entryCount)
-			entry := entries[entryIndex]
-			elem := elements[entryIndex]
-
-			switch op {
-			case opPushFront:
-				if elem == nil {
-					got.PushFront(entry)
-					elements[entryIndex] = want.PushFront(entry)
-				}
-			case opPushBack:
-				if elem == nil {
-					got.PushBack(entry)
-					elements[entryIndex] = want.PushBack(entry)
-				}
-			case opRemove:
-				if elem != nil {
-					got.Remove(entry)
-					want.Remove(elem)
-					elements[entryIndex] = nil
-				}
-			case opMoveToFront:
-				if elem != nil {
-					got.MoveToFront(entry)
-					want.MoveToFront(elem)
-				}
-			case opRemoveFront:
-				gotFront := got.Front()
-				wantFront := listElementEntry(want.Front())
-				if gotFront != wantFront {
-					t.Fatalf("op %d: Front() before Remove = %s, want %s",
-						opIndex, intrusiveListEntryName(gotFront), intrusiveListEntryName(wantFront))
-				}
-				if gotFront != nil {
-					got.Remove(gotFront)
-					want.Remove(want.Front())
-					elements[gotFront.id] = nil
-				}
-			case opCheckPrevCircular:
-				if elem != nil {
-					gotPrev := got.PrevCircular(entry)
-					wantPrev := prevCircularListElement(&want, elem)
-					if gotPrev != wantPrev {
-						t.Fatalf("op %d: PrevCircular(%d) = %s, want %s",
-							opIndex, entry.id, intrusiveListEntryName(gotPrev), intrusiveListEntryName(wantPrev))
-					}
-				}
-			}
-
-			assertIntrusiveListMatchesContainer(t, &got, &want)
-			assertDetachedIntrusiveListEntries(t, entries, elements)
+		steps := make([]intrusiveListStep, len(rawSteps))
+		for i, rawStep := range rawSteps {
+			steps[i] = decodeIntrusiveListStep(rawStep, entryCount)
 		}
+		runIntrusiveListSteps(t, steps)
 	})
 }
 
+type intrusiveListOp byte
+
 const (
-	opPushFront byte = iota
+	opPushFront intrusiveListOp = iota
 	opPushBack
 	opRemove
 	opMoveToFront
@@ -201,12 +75,118 @@ const (
 	opCheckPrevCircular
 )
 
-func intrusiveListOp(op byte, entryIndex int) byte {
-	return op&0x07 | byte(entryIndex<<3)
+type intrusiveListStep struct {
+	op    intrusiveListOp
+	entry int
 }
 
-func decodeIntrusiveListOp(rawOp byte, entryCount int) (byte, int) {
-	return rawOp & 0x07, int(rawOp>>3) % entryCount
+func pushFront(entry int) intrusiveListStep {
+	return intrusiveListStep{op: opPushFront, entry: entry}
+}
+
+func pushBack(entry int) intrusiveListStep {
+	return intrusiveListStep{op: opPushBack, entry: entry}
+}
+
+func removeEntry(entry int) intrusiveListStep {
+	return intrusiveListStep{op: opRemove, entry: entry}
+}
+
+func moveToFront(entry int) intrusiveListStep {
+	return intrusiveListStep{op: opMoveToFront, entry: entry}
+}
+
+func removeFront() intrusiveListStep {
+	return intrusiveListStep{op: opRemoveFront}
+}
+
+func checkPrevCircular(entry int) intrusiveListStep {
+	return intrusiveListStep{op: opCheckPrevCircular, entry: entry}
+}
+
+func runIntrusiveListSteps(t *testing.T, steps []intrusiveListStep) {
+	t.Helper()
+
+	const entryCount = 16
+	entries := newIntrusiveListTestEntries(entryCount)
+	elements := make([]*list.Element, entryCount)
+	var got intrusiveList[*intrusiveListTestEntry]
+	var want list.List
+
+	assertIntrusiveListMatchesContainer(t, &got, &want)
+	assertRemovedIntrusiveListEntriesDetached(t, entries, elements)
+	for stepIndex, step := range steps {
+		entryIndex := step.entry % entryCount
+		entry := entries[entryIndex]
+		elem := elements[entryIndex]
+
+		switch step.op {
+		case opPushFront:
+			if elem == nil {
+				got.PushFront(entry)
+				elements[entryIndex] = want.PushFront(entry)
+			}
+		case opPushBack:
+			if elem == nil {
+				got.PushBack(entry)
+				elements[entryIndex] = want.PushBack(entry)
+			}
+		case opRemove:
+			if elem != nil {
+				got.Remove(entry)
+				want.Remove(elem)
+				elements[entryIndex] = nil
+			}
+		case opMoveToFront:
+			if elem != nil {
+				got.MoveToFront(entry)
+				want.MoveToFront(elem)
+			}
+		case opRemoveFront:
+			gotFront := got.Front()
+			wantFront := listElementEntry(want.Front())
+			if gotFront != wantFront {
+				t.Fatalf("step %d: Front() before Remove = %s, want %s",
+					stepIndex, intrusiveListEntryName(gotFront), intrusiveListEntryName(wantFront))
+			}
+			if gotFront != nil {
+				got.Remove(gotFront)
+				want.Remove(want.Front())
+				elements[gotFront.id] = nil
+			}
+		case opCheckPrevCircular:
+			if elem != nil {
+				gotPrev := got.PrevCircular(entry)
+				wantPrev := prevCircularListElement(&want, elem)
+				if gotPrev != wantPrev {
+					t.Fatalf("step %d: PrevCircular(%d) = %s, want %s",
+						stepIndex, entry.id, intrusiveListEntryName(gotPrev), intrusiveListEntryName(wantPrev))
+				}
+			}
+		}
+
+		assertIntrusiveListMatchesContainer(t, &got, &want)
+		assertRemovedIntrusiveListEntriesDetached(t, entries, elements)
+	}
+}
+
+func encodeIntrusiveListSteps(steps ...intrusiveListStep) []byte {
+	encoded := make([]byte, len(steps))
+	for i, step := range steps {
+		encoded[i] = step.encode()
+	}
+	return encoded
+}
+
+func decodeIntrusiveListStep(encoded byte, entryCount int) intrusiveListStep {
+	return intrusiveListStep{
+		op:    intrusiveListOp(encoded & 0x07),
+		entry: int(encoded>>3) % entryCount,
+	}
+}
+
+func (step intrusiveListStep) encode() byte {
+	return byte(step.op)&0x07 | byte(step.entry<<3)
 }
 
 func newIntrusiveListTestEntries(n int) []*intrusiveListTestEntry {
@@ -217,82 +197,6 @@ func newIntrusiveListTestEntries(n int) []*intrusiveListTestEntry {
 	return entries
 }
 
-func assertIntrusiveList(
-	t *testing.T,
-	list *intrusiveList[*intrusiveListTestEntry],
-	want ...*intrusiveListTestEntry,
-) {
-	t.Helper()
-
-	if got := list.Len(); got != len(want) {
-		t.Fatalf("Len() = %d, want %d", got, len(want))
-	}
-	if got, want := list.Front(), firstIntrusiveListEntry(want); got != want {
-		t.Fatalf("Front() = %s, want %s", intrusiveListEntryName(got), intrusiveListEntryName(want))
-	}
-	if got, want := list.Back(), lastIntrusiveListEntry(want); got != want {
-		t.Fatalf("Back() = %s, want %s", intrusiveListEntryName(got), intrusiveListEntryName(want))
-	}
-
-	var prev *intrusiveListTestEntry
-	count := 0
-	for entry := list.Front(); entry != nil; entry = entry.list.next {
-		if count >= len(want) {
-			t.Fatalf("list has more than %d entries or contains a cycle", len(want))
-		}
-		if entry != want[count] {
-			t.Fatalf("entry %d = %s, want %s",
-				count, intrusiveListEntryName(entry), intrusiveListEntryName(want[count]))
-		}
-		if entry.list.prev != prev {
-			t.Fatalf("entry %d prev = %s, want %s",
-				entry.id, intrusiveListEntryName(entry.list.prev), intrusiveListEntryName(prev))
-		}
-		prev = entry
-		count++
-	}
-	if count != len(want) {
-		t.Fatalf("walked %d entries, want %d", count, len(want))
-	}
-}
-
-func assertPrevCircular(
-	t *testing.T,
-	list *intrusiveList[*intrusiveListTestEntry],
-	entry *intrusiveListTestEntry,
-	want *intrusiveListTestEntry,
-) {
-	t.Helper()
-
-	if got := list.PrevCircular(entry); got != want {
-		t.Fatalf("PrevCircular(%d) = %s, want %s",
-			entry.id, intrusiveListEntryName(got), intrusiveListEntryName(want))
-	}
-}
-
-func assertDetachedIntrusiveListEntries(
-	t *testing.T,
-	entries []*intrusiveListTestEntry,
-	elements []*list.Element,
-) {
-	t.Helper()
-
-	for i, entry := range entries {
-		if elements[i] == nil {
-			assertDetachedIntrusiveListEntry(t, entry)
-		}
-	}
-}
-
-func assertDetachedIntrusiveListEntry(t *testing.T, entry *intrusiveListTestEntry) {
-	t.Helper()
-
-	if entry.list.prev != nil || entry.list.next != nil {
-		t.Fatalf("entry %d links = prev %s next %s, want detached",
-			entry.id, intrusiveListEntryName(entry.list.prev), intrusiveListEntryName(entry.list.next))
-	}
-}
-
 func assertIntrusiveListMatchesContainer(
 	t *testing.T,
 	got *intrusiveList[*intrusiveListTestEntry],
@@ -300,11 +204,57 @@ func assertIntrusiveListMatchesContainer(
 ) {
 	t.Helper()
 
-	entries := make([]*intrusiveListTestEntry, 0, want.Len())
-	for elem := want.Front(); elem != nil; elem = elem.Next() {
-		entries = append(entries, elem.Value.(*intrusiveListTestEntry))
+	if got.Len() != want.Len() {
+		t.Fatalf("Len() = %d, want %d", got.Len(), want.Len())
 	}
-	assertIntrusiveList(t, got, entries...)
+	if got.Front() != listElementEntry(want.Front()) {
+		t.Fatalf("Front() = %s, want %s",
+			intrusiveListEntryName(got.Front()), intrusiveListEntryName(listElementEntry(want.Front())))
+	}
+	if got.Back() != listElementEntry(want.Back()) {
+		t.Fatalf("Back() = %s, want %s",
+			intrusiveListEntryName(got.Back()), intrusiveListEntryName(listElementEntry(want.Back())))
+	}
+
+	prev := (*intrusiveListTestEntry)(nil)
+	gotEntry := got.Front()
+	for index, wantElem := 0, want.Front(); wantElem != nil; index, wantElem = index+1, wantElem.Next() {
+		if gotEntry == nil {
+			t.Fatalf("entry %d = nil, want %s", index, intrusiveListEntryName(listElementEntry(wantElem)))
+		}
+		if gotEntry != listElementEntry(wantElem) {
+			t.Fatalf("entry %d = %s, want %s",
+				index, intrusiveListEntryName(gotEntry), intrusiveListEntryName(listElementEntry(wantElem)))
+		}
+		if gotEntry.list.prev != prev {
+			t.Fatalf("entry %d prev = %s, want %s",
+				gotEntry.id, intrusiveListEntryName(gotEntry.list.prev), intrusiveListEntryName(prev))
+		}
+
+		prev = gotEntry
+		gotEntry = gotEntry.list.next
+	}
+	if gotEntry != nil {
+		t.Fatalf("list has trailing entry %s", intrusiveListEntryName(gotEntry))
+	}
+}
+
+func assertRemovedIntrusiveListEntriesDetached(
+	t *testing.T,
+	entries []*intrusiveListTestEntry,
+	elements []*list.Element,
+) {
+	t.Helper()
+
+	for i, entry := range entries {
+		if elements[i] != nil {
+			continue
+		}
+		if entry.list.prev != nil || entry.list.next != nil {
+			t.Fatalf("entry %d links = prev %s next %s, want detached",
+				entry.id, intrusiveListEntryName(entry.list.prev), intrusiveListEntryName(entry.list.next))
+		}
+	}
 }
 
 func prevCircularListElement(l *list.List, elem *list.Element) *intrusiveListTestEntry {
@@ -312,7 +262,7 @@ func prevCircularListElement(l *list.List, elem *list.Element) *intrusiveListTes
 		return nil
 	}
 	if prev := elem.Prev(); prev != nil {
-		return prev.Value.(*intrusiveListTestEntry)
+		return listElementEntry(prev)
 	}
 	return listElementEntry(l.Back())
 }
@@ -322,20 +272,6 @@ func listElementEntry(elem *list.Element) *intrusiveListTestEntry {
 		return nil
 	}
 	return elem.Value.(*intrusiveListTestEntry)
-}
-
-func firstIntrusiveListEntry(entries []*intrusiveListTestEntry) *intrusiveListTestEntry {
-	if len(entries) == 0 {
-		return nil
-	}
-	return entries[0]
-}
-
-func lastIntrusiveListEntry(entries []*intrusiveListTestEntry) *intrusiveListTestEntry {
-	if len(entries) == 0 {
-		return nil
-	}
-	return entries[len(entries)-1]
 }
 
 func intrusiveListEntryName(entry *intrusiveListTestEntry) string {

--- a/pkg/framecache/lru.go
+++ b/pkg/framecache/lru.go
@@ -11,9 +11,9 @@ type LRU struct {
 }
 
 type lruEntry struct {
-	frameID int64
-	data    []byte
-	intrusiveLinks[*lruEntry]
+	frameID                   int64
+	data                      []byte
+	intrusiveLinks[*lruEntry] //nolint:unused // Used through method promotion by intrusiveList.
 }
 
 // NewLRU returns an LRU cache with the provided limits.

--- a/pkg/framecache/lru.go
+++ b/pkg/framecache/lru.go
@@ -1,39 +1,42 @@
 package framecache
 
-import "container/list"
-
 // LRU is a decoded-frame cache that evicts the least recently used frame.
 //
 // Put and successful Get calls mark frames most recently used.
 type LRU struct {
 	limits Limits
-	items  map[int64]*list.Element
-	order  list.List
+	items  map[int64]*lruEntry
+	order  intrusiveList[*lruEntry]
 	bytes  uint64
 }
 
 type lruEntry struct {
 	frameID int64
 	data    []byte
+	list    intrusiveLinks[*lruEntry]
+}
+
+func (entry *lruEntry) links() *intrusiveLinks[*lruEntry] {
+	return &entry.list
 }
 
 // NewLRU returns an LRU cache with the provided limits.
 func NewLRU(limits Limits) *LRU {
 	return &LRU{
 		limits: limits,
-		items:  make(map[int64]*list.Element),
+		items:  make(map[int64]*lruEntry),
 	}
 }
 
 // Get returns the frame stored for frameID, if any. On a hit, Get marks the
 // frame most recently used.
 func (c *LRU) Get(frameID int64) ([]byte, bool) {
-	elem, ok := c.items[frameID]
+	entry, ok := c.items[frameID]
 	if !ok {
 		return nil, false
 	}
-	c.order.MoveToFront(elem)
-	return elem.Value.(*lruEntry).data, true
+	c.order.MoveToFront(entry)
+	return entry.data, true
 }
 
 // Put stores data for frameID, replacing any existing frame and marking it most
@@ -45,18 +48,18 @@ func (c *LRU) Put(frameID int64, data []byte) {
 		return
 	}
 
-	if elem, ok := c.items[frameID]; ok {
-		entry := elem.Value.(*lruEntry)
+	if entry, ok := c.items[frameID]; ok {
 		c.bytes -= uint64(len(entry.data))
 		entry.data = data
 		c.bytes += size
-		c.order.MoveToFront(elem)
+		c.order.MoveToFront(entry)
 		c.evict()
 		return
 	}
 
 	entry := &lruEntry{frameID: frameID, data: data}
-	c.items[frameID] = c.order.PushFront(entry)
+	c.order.PushFront(entry)
+	c.items[frameID] = entry
 	c.bytes += uint64(len(entry.data))
 	c.evict()
 }
@@ -69,26 +72,25 @@ func (c *LRU) Clear() {
 }
 
 func (c *LRU) remove(frameID int64) {
-	elem, ok := c.items[frameID]
+	entry, ok := c.items[frameID]
 	if !ok {
 		return
 	}
-	c.removeElement(elem)
+	c.removeElement(entry)
 }
 
-func (c *LRU) removeElement(elem *list.Element) {
-	entry := elem.Value.(*lruEntry)
+func (c *LRU) removeElement(entry *lruEntry) {
 	delete(c.items, entry.frameID)
 	c.bytes -= uint64(len(entry.data))
-	c.order.Remove(elem)
+	c.order.Remove(entry)
 }
 
 func (c *LRU) evict() {
 	for c.limits.overLimits(c.order.Len(), c.bytes) {
-		elem := c.order.Back()
-		if elem == nil {
+		entry := c.order.Back()
+		if entry == nil {
 			return
 		}
-		c.removeElement(elem)
+		c.removeElement(entry)
 	}
 }

--- a/pkg/framecache/lru.go
+++ b/pkg/framecache/lru.go
@@ -54,8 +54,7 @@ func (c *LRU) Put(frameID int64, data []byte) {
 	}
 
 	entry := &lruEntry{frameID: frameID, data: data}
-	c.order.PushFront(entry)
-	c.items[frameID] = entry
+	c.items[frameID] = c.order.PushFront(entry)
 	c.bytes += uint64(len(entry.data))
 	c.evict()
 }

--- a/pkg/framecache/lru.go
+++ b/pkg/framecache/lru.go
@@ -13,11 +13,7 @@ type LRU struct {
 type lruEntry struct {
 	frameID int64
 	data    []byte
-	list    intrusiveLinks[*lruEntry]
-}
-
-func (entry *lruEntry) links() *intrusiveLinks[*lruEntry] {
-	return &entry.list
+	intrusiveLinks[*lruEntry]
 }
 
 // NewLRU returns an LRU cache with the provided limits.

--- a/pkg/framecache/sieve.go
+++ b/pkg/framecache/sieve.go
@@ -19,11 +19,7 @@ type sieveEntry struct {
 	frameID int64
 	data    []byte
 	count   uint8
-	list    intrusiveLinks[*sieveEntry]
-}
-
-func (entry *sieveEntry) links() *intrusiveLinks[*sieveEntry] {
-	return &entry.list
+	intrusiveLinks[*sieveEntry]
 }
 
 // NewSieve returns a Sieve cache with the provided limits.

--- a/pkg/framecache/sieve.go
+++ b/pkg/framecache/sieve.go
@@ -1,7 +1,5 @@
 package framecache
 
-import "container/list"
-
 // Sieve is a decoded-frame cache using the SIEVE-k replacement policy.
 //
 // Hits and updates increment a per-entry counter, capped at 16. During
@@ -9,9 +7,9 @@ import "container/list"
 // entry with a zero counter is evicted.
 type Sieve struct {
 	limits Limits
-	items  map[int64]*list.Element
-	order  list.List
-	hand   *list.Element
+	items  map[int64]*sieveEntry
+	order  intrusiveList[*sieveEntry]
+	hand   *sieveEntry
 	bytes  uint64
 }
 
@@ -21,24 +19,28 @@ type sieveEntry struct {
 	frameID int64
 	data    []byte
 	count   uint8
+	list    intrusiveLinks[*sieveEntry]
+}
+
+func (entry *sieveEntry) links() *intrusiveLinks[*sieveEntry] {
+	return &entry.list
 }
 
 // NewSieve returns a Sieve cache with the provided limits.
 func NewSieve(limits Limits) *Sieve {
 	return &Sieve{
 		limits: limits,
-		items:  make(map[int64]*list.Element),
+		items:  make(map[int64]*sieveEntry),
 	}
 }
 
 // Get returns the frame stored for frameID, if any. On a hit, Get increments
 // the frame's counter.
 func (c *Sieve) Get(frameID int64) ([]byte, bool) {
-	elem, ok := c.items[frameID]
+	entry, ok := c.items[frameID]
 	if !ok {
 		return nil, false
 	}
-	entry := elem.Value.(*sieveEntry)
 	entry.touch()
 	return entry.data, true
 }
@@ -51,20 +53,19 @@ func (c *Sieve) Put(frameID int64, data []byte) {
 		return
 	}
 
-	if elem, ok := c.items[frameID]; ok {
-		entry := elem.Value.(*sieveEntry)
+	if entry, ok := c.items[frameID]; ok {
 		c.bytes -= uint64(len(entry.data))
 		entry.data = data
 		entry.touch()
 		c.bytes += size
-		c.evictForExcept(0, 0, elem)
+		c.evictForExcept(0, 0, entry)
 		return
 	}
 
 	c.evictFor(1, size)
 	entry := &sieveEntry{frameID: frameID, data: data}
-	elem := c.order.PushFront(entry)
-	c.items[frameID] = elem
+	c.order.PushFront(entry)
+	c.items[frameID] = entry
 	c.bytes += uint64(len(entry.data))
 	if c.hand == nil {
 		c.hand = c.order.Back()
@@ -80,24 +81,23 @@ func (c *Sieve) Clear() {
 }
 
 func (c *Sieve) remove(frameID int64) {
-	elem, ok := c.items[frameID]
+	entry, ok := c.items[frameID]
 	if !ok {
 		return
 	}
-	c.removeElement(elem)
+	c.removeElement(entry)
 }
 
-func (c *Sieve) removeElement(elem *list.Element) {
-	next := c.prevCircular(elem)
-	entry := elem.Value.(*sieveEntry)
+func (c *Sieve) removeElement(entry *sieveEntry) {
+	next := c.order.PrevCircular(entry)
 	delete(c.items, entry.frameID)
 	c.bytes -= uint64(len(entry.data))
-	c.order.Remove(elem)
+	c.order.Remove(entry)
 
 	switch {
 	case c.order.Len() == 0:
 		c.hand = nil
-	case c.hand == elem:
+	case c.hand == entry:
 		if next != nil {
 			c.hand = next
 		} else {
@@ -110,7 +110,7 @@ func (c *Sieve) evictFor(extraFrames int, extraBytes uint64) {
 	c.evictForExcept(extraFrames, extraBytes, nil)
 }
 
-func (c *Sieve) evictForExcept(extraFrames int, extraBytes uint64, protected *list.Element) {
+func (c *Sieve) evictForExcept(extraFrames int, extraBytes uint64, protected *sieveEntry) {
 	for c.limits.overLimits(c.order.Len()+extraFrames, c.bytes+extraBytes) {
 		if c.hand == nil {
 			c.hand = c.order.Back()
@@ -121,7 +121,7 @@ func (c *Sieve) evictForExcept(extraFrames int, extraBytes uint64, protected *li
 
 		elem := c.hand
 		if elem == protected {
-			next := c.prevCircular(elem)
+			next := c.order.PrevCircular(elem)
 			if next == nil {
 				return
 			}
@@ -129,10 +129,9 @@ func (c *Sieve) evictForExcept(extraFrames int, extraBytes uint64, protected *li
 			continue
 		}
 
-		entry := elem.Value.(*sieveEntry)
-		if entry.count > 0 {
-			entry.count--
-			next := c.prevCircular(elem)
+		if elem.count > 0 {
+			elem.count--
+			next := c.order.PrevCircular(elem)
 			if next != nil {
 				c.hand = next
 			}
@@ -147,14 +146,4 @@ func (entry *sieveEntry) touch() {
 	if entry.count < sieveMaxCount {
 		entry.count++
 	}
-}
-
-func (c *Sieve) prevCircular(elem *list.Element) *list.Element {
-	if c.order.Len() <= 1 {
-		return nil
-	}
-	if prev := elem.Prev(); prev != nil {
-		return prev
-	}
-	return c.order.Back()
 }

--- a/pkg/framecache/sieve.go
+++ b/pkg/framecache/sieve.go
@@ -60,8 +60,7 @@ func (c *Sieve) Put(frameID int64, data []byte) {
 
 	c.evictFor(1, size)
 	entry := &sieveEntry{frameID: frameID, data: data}
-	c.order.PushFront(entry)
-	c.items[frameID] = entry
+	c.items[frameID] = c.order.PushFront(entry)
 	c.bytes += uint64(len(entry.data))
 	if c.hand == nil {
 		c.hand = c.order.Back()

--- a/pkg/framecache/sieve.go
+++ b/pkg/framecache/sieve.go
@@ -16,10 +16,10 @@ type Sieve struct {
 const sieveMaxCount = 16
 
 type sieveEntry struct {
-	frameID int64
-	data    []byte
-	count   uint8
-	intrusiveLinks[*sieveEntry]
+	frameID                     int64
+	data                        []byte
+	count                       uint8
+	intrusiveLinks[*sieveEntry] //nolint:unused // Used through method promotion by intrusiveList.
 }
 
 // NewSieve returns a Sieve cache with the provided limits.


### PR DESCRIPTION
## Summary

Replace the frame cache internals for FIFO, LRU, and Sieve with a small package-private intrusive list. The public `framecache.Cache` API, constructors, and replacement-policy behavior are unchanged.

## User Impact

This removes the extra `container/list.Element` allocation on cache insertions while keeping the cache implementations simple: entries are still allocated normally, and there are no freelists or recycling paths.

## Benchmarks

Measured from `pkg` with `go test -run '^$' -bench '^BenchmarkReaderFrameCache' -benchmem` on linux/amd64.

| Workload | Cache | CPU before | CPU after | Allocs/op | Bytes/op |
| --- | --- | ---: | ---: | ---: | ---: |
| Uniform | FIFO | 2813 ns/op | 2691 ns/op (-4.3%) | 10 -> 9 | 464 -> 433 |
| Uniform | LRU | 2851 ns/op | 2689 ns/op (-5.7%) | 10 -> 9 | 464 -> 433 |
| Uniform | SieveK16 | 2882 ns/op | 2659 ns/op (-7.7%) | 10 -> 9 | 479 -> 448 |
| Zipf | FIFO | 1193 ns/op | 1155 ns/op (-3.2%) | 7 -> 7 | 352 -> 349 |
| Zipf | LRU | 1221 ns/op | 1224 ns/op (+0.2%) | 7 -> 7 | 350 -> 347 |
| Zipf | SieveK16 | 1125 ns/op | 1108 ns/op (-1.5%) | 7 -> 7 | 350 -> 347 |
| Gaussian | FIFO | 2115 ns/op | 1953 ns/op (-7.7%) | 9 -> 8 | 409 -> 391 |
| Gaussian | LRU | 2095 ns/op | 1997 ns/op (-4.7%) | 9 -> 8 | 406 -> 389 |
| Gaussian | SieveK16 | 1910 ns/op | 1867 ns/op (-2.3%) | 8 -> 8 | 406 -> 391 |

The allocation reduction shows up on insert-heavy paths: uniform workloads drop from 10 to 9 allocs/op, and Gaussian FIFO/LRU drop from 9 to 8 allocs/op. Zipf is mostly cache hits, so allocs/op are unchanged there.

## Implementation Notes

`intrusiveList[T]` mirrors the subset of `container/list` used by the caches: `Init`, `Len`, `Front`, `Back`, `PushFront`, `PushBack`, `Remove`, and `MoveToFront`. Cache entries embed their intrusive links directly, so FIFO/LRU/Sieve do not need per-entry wrapper methods or separate list elements.

## Validation

- `go test ./framecache`
- `go test ./framecache -run '^$' -fuzz '^FuzzIntrusiveListOperations$' -fuzztime=10s`
- `go test ./...`
- `go test -run '^$' -bench '^BenchmarkReaderFrameCache' -benchmem`