### PR TITLE
pkg: compact seek table index entries

### DIFF
--- a/pkg/frame_offset.go
+++ b/pkg/frame_offset.go
@@ -21,6 +21,25 @@ type FrameOffsetEntry struct {
 	Checksum uint32
 }
 
+type seekTableIndexEntry struct {
+	CompressedOffset   uint64
+	DecompressedOffset uint64
+	CompressedSize     uint32
+	DecompressedSize   uint32
+	Checksum           uint32
+}
+
+func (e seekTableIndexEntry) frameOffsetEntry(id int64) FrameOffsetEntry {
+	return FrameOffsetEntry{
+		ID:                 id,
+		CompressedOffset:   e.CompressedOffset,
+		DecompressedOffset: e.DecompressedOffset,
+		CompressedSize:     e.CompressedSize,
+		DecompressedSize:   e.DecompressedSize,
+		Checksum:           e.Checksum,
+	}
+}
+
 // LogValue implements slog.LogValuer.
 func (o FrameOffsetEntry) LogValue() slog.Value {
 	return slog.GroupValue(

--- a/pkg/seek_table.go
+++ b/pkg/seek_table.go
@@ -8,7 +8,7 @@ import "sort"
 // WriterEnvironment.WriteSeekTable or returned by Encoder.EndStream. Lookup methods
 // can be used concurrently.
 type SeekTable struct {
-	entries   []FrameOffsetEntry
+	entries   []seekTableIndexEntry
 	checksums bool
 }
 
@@ -62,7 +62,7 @@ func (t SeekTable) EntryByDecompressedOffset(off uint64) (FrameOffsetEntry, bool
 	if n == len(t.entries) || t.entries[n].DecompressedOffset > off {
 		return FrameOffsetEntry{}, false
 	}
-	return t.entries[n], true
+	return t.entries[n].frameOffsetEntry(int64(n)), true
 }
 
 // EntryByID returns the frame with id.
@@ -72,5 +72,5 @@ func (t SeekTable) EntryByID(id int64) (FrameOffsetEntry, bool) {
 		return FrameOffsetEntry{}, false
 	}
 
-	return t.entries[int(id)], true
+	return t.entries[int(id)].frameOffsetEntry(id), true
 }

--- a/pkg/seek_table_parser.go
+++ b/pkg/seek_table_parser.go
@@ -113,7 +113,7 @@ func seekTableEntrySize(checksum bool) int64 {
 	return baseSize
 }
 
-func parseSeekTableEntries(p []byte, entrySize uint64, numberOfFrames uint32) ([]FrameOffsetEntry, error) {
+func parseSeekTableEntries(p []byte, entrySize uint64, numberOfFrames uint32) ([]seekTableIndexEntry, error) {
 	if entrySize == 0 {
 		return nil, fmt.Errorf("seek table entry size is 0")
 	}
@@ -126,11 +126,10 @@ func parseSeekTableEntries(p []byte, entrySize uint64, numberOfFrames uint32) ([
 			parsedEntries, numberOfFrames)
 	}
 
-	entries := make([]FrameOffsetEntry, 0, int(parsedEntries))
+	entries := make([]seekTableIndexEntry, 0, int(parsedEntries))
 	entry := seekTableEntry{}
 	var compressedOffset, decompressedOffset uint64
 
-	var i int64
 	for indexOffset := uint64(0); indexOffset < uint64(len(p)); indexOffset += entrySize {
 		err := entry.UnmarshalBinary(p[indexOffset : indexOffset+entrySize])
 		if err != nil {
@@ -138,8 +137,7 @@ func parseSeekTableEntries(p []byte, entrySize uint64, numberOfFrames uint32) ([
 				p[indexOffset:indexOffset+entrySize], indexOffset, err)
 		}
 
-		entries = append(entries, FrameOffsetEntry{
-			ID:                 i,
+		entries = append(entries, seekTableIndexEntry{
 			CompressedOffset:   compressedOffset,
 			DecompressedOffset: decompressedOffset,
 			CompressedSize:     entry.CompressedSize,
@@ -148,7 +146,6 @@ func parseSeekTableEntries(p []byte, entrySize uint64, numberOfFrames uint32) ([
 		})
 		compressedOffset += uint64(entry.CompressedSize)
 		decompressedOffset += uint64(entry.DecompressedSize)
-		i++
 	}
 
 	return entries, nil


### PR DESCRIPTION
## Summary

This stores parsed seek-table entries in a compact private type that omits the redundant `ID` field. `ID` is derived from the entry's slice position when returning a public `FrameOffsetEntry`.

## Public API

The public `SeekTable` API is unchanged. `EntryByID` and `EntryByDecompressedOffset` still return `FrameOffsetEntry` values with the expected `ID`, offsets, sizes, and checksum fields.

## Correctness Notes

The compact type is private to the package. Lookup methods reconstruct the public entry at the API boundary, so callers do not observe the internal representation change.

## Benchmarks

`BenchmarkSeekTableIndexBuild/1M` dropped from roughly `41,943,072 B/op` to `33,554,464 B/op`, while remaining at `2 allocs/op`.

Seek-table lookup benchmarks remain `0 allocs/op`. There is a small CPU tradeoff from reconstructing the public `FrameOffsetEntry` on lookup.

## Tests

`go test ./...`

`go test -run '^$' -bench '^BenchmarkSeekTableIndexBuild' -benchmem`

`go test -run '^$' -bench '^BenchmarkSeekTableEntryBy' -benchmem`