### PR TITLE
cmd: bump pkg to v0.10.0-rc.2

### DIFF
--- a/cmd/zstdseek/go.mod
+++ b/cmd/zstdseek/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/SaveTheRbtz/fastcdc-go v0.3.0
-	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0-rc.1
+	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0-rc.2
 	github.com/klauspost/compress v1.18.6
 	github.com/schollz/progressbar/v3 v3.19.0
 	golang.org/x/term v0.43.0

--- a/cmd/zstdseek/go.sum
+++ b/cmd/zstdseek/go.sum
@@ -1,7 +1,7 @@
 github.com/SaveTheRbtz/fastcdc-go v0.3.0 h1:JdHvLlnijDuisYIwpRDcHZEjbxvCqtEmJ3gf35VJBgA=
 github.com/SaveTheRbtz/fastcdc-go v0.3.0/go.mod h1:2kMKqvBv1h9wCaUfETqsVkSESsCiFhp4YyEHyz7/SfE=
-github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0-rc.1 h1:/ngQs30lKmLhZYf9aMH4LGQX/7YQJxZaWcjskyzKv5E=
-github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0-rc.1/go.mod h1:I28hc9eaiqKCoOB+9Wh/P1IOScfm0xCgyWC6DAo0lmo=
+github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0-rc.2 h1:TC7jBL2sf3hlPGbfOYfzhZsAdclWO1NzqmjcZ4eGe0U=
+github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0-rc.2/go.mod h1:I28hc9eaiqKCoOB+9Wh/P1IOScfm0xCgyWC6DAo0lmo=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chengxilo/virtualterm v1.0.4 h1:Z6IpERbRVlfB8WkOmtbHiDbBANU7cimRIof7mk9/PwM=


### PR DESCRIPTION
## Summary

Bump the `cmd/zstdseek` module dependency on `github.com/SaveTheRbtz/zstd-seekable-format-go/pkg` from `v0.10.0-rc.1` to the `v0.10.0-rc.2` package release candidate.

This keeps the command module aligned with the newly published package release candidate without changing command code.

## Validation

- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go test ./...` from `cmd/zstdseek`
