### PR TITLE
cmd: add zstdseek compression threads flag

### DIFF
--- a/cmd/zstdseek/main.go
+++ b/cmd/zstdseek/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -38,12 +39,23 @@ func newLogger(verbose bool) *slog.Logger {
 	return slog.New(slog.NewJSONHandler(os.Stderr, opts))
 }
 
+func compressionConcurrency(threads, defaultConcurrency int) (int, bool) {
+	if threads < 0 {
+		return 0, false
+	}
+	if threads == 0 {
+		return defaultConcurrency, true
+	}
+	return threads, true
+}
+
 func main() {
 	ctx := context.Background()
+	defaultConcurrency := runtime.GOMAXPROCS(0)
 
 	var (
 		inputFlag, chunkingFlag, outputFlag string
-		qualityFlag                         int
+		qualityFlag, threadsFlag            int
 		verifyFlag, verboseFlag             bool
 	)
 
@@ -52,6 +64,7 @@ func main() {
 	flag.StringVar(&chunkingFlag, "c", "128:1024:8192", "min:avg:max chunking block size (in kb)")
 	flag.BoolVar(&verifyFlag, "t", false, "test reading after the write")
 	flag.IntVar(&qualityFlag, "q", 1, "compression quality (lower == faster)")
+	flag.IntVar(&threadsFlag, "threads", defaultConcurrency, "number of concurrent compression workers (0 = runtime CPU count)")
 	flag.BoolVar(&verboseFlag, "v", false, "be verbose")
 
 	flag.Parse()
@@ -69,6 +82,10 @@ func main() {
 	}
 	if verifyFlag && outputFlag == "-" {
 		fatal("verify can't be used with stdout output")
+	}
+	concurrency, ok := compressionConcurrency(threadsFlag, defaultConcurrency)
+	if !ok {
+		fatal("compression workers must be non-negative", slog.Int("threads", threadsFlag))
 	}
 
 	bar := progressbar.DefaultSilent(0, "")
@@ -177,9 +194,12 @@ func main() {
 		return bytes.Clone(chunk.Data), nil
 	}
 
-	err = w.WriteMany(ctx, frameSource, seekable.WithWriteCallback(func(entry seekable.FrameOffsetEntry) {
-		_ = bar.Add(int(entry.DecompressedSize))
-	}))
+	err = w.WriteMany(ctx, frameSource,
+		seekable.WithConcurrency(concurrency),
+		seekable.WithWriteCallback(func(entry seekable.FrameOffsetEntry) {
+			_ = bar.Add(int(entry.DecompressedSize))
+		}),
+	)
 	if err != nil {
 		fatal("failed to write data", slog.Any("error", err))
 	}

--- a/cmd/zstdseek/main_test.go
+++ b/cmd/zstdseek/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import "testing"
+
+func TestCompressionConcurrency(t *testing.T) {
+	tests := []struct {
+		name               string
+		threads            int
+		defaultConcurrency int
+		want               int
+		wantOK             bool
+	}{
+		{
+			name:               "default",
+			threads:            0,
+			defaultConcurrency: 8,
+			want:               8,
+			wantOK:             true,
+		},
+		{
+			name:               "explicit",
+			threads:            2,
+			defaultConcurrency: 8,
+			want:               2,
+			wantOK:             true,
+		},
+		{
+			name:               "negative",
+			threads:            -1,
+			defaultConcurrency: 8,
+			wantOK:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := compressionConcurrency(tt.threads, tt.defaultConcurrency)
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("compressionConcurrency(%d, %d) = (%d, %t), want (%d, %t)",
+					tt.threads, tt.defaultConcurrency, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a Go-style `-threads` flag to `zstdseek` so callers can limit concurrent compression work from the CLI. The flag defaults to `runtime.GOMAXPROCS(0)`, and `-threads=0` resolves to that runtime CPU count before calling `seekable.WithConcurrency`.

This answers the CLI side of #287 and covers the same concurrency-flag request listed in #169.

## Validation

- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go test ./...` in `cmd/zstdseek`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go test ./...` in `pkg`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go run . -threads=1 -f ../../README.md -o /tmp/codex-zstdseek.zst -t`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go run . -h`

Closes #287.