### PR TITLE
cmd: use text console logging

### DIFF
--- a/cmd/zstdseek/main.go
+++ b/cmd/zstdseek/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha512"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"io"
@@ -30,12 +31,7 @@ func newLogger(verbose bool) *slog.Logger {
 	if verbose {
 		level = slog.LevelDebug
 	}
-
-	opts := &slog.HandlerOptions{Level: level}
-	if verbose {
-		return slog.New(slog.NewTextHandler(os.Stderr, opts))
-	}
-	return slog.New(slog.NewJSONHandler(os.Stderr, opts))
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
 }
 
 func main() {
@@ -215,11 +211,14 @@ func main() {
 		}
 		<-origDone
 
-		if !bytes.Equal(actual.Sum(nil), expected.Sum(nil)) {
+		actualSum := actual.Sum(nil)
+		expectedSum := expected.Sum(nil)
+		if !bytes.Equal(actualSum, expectedSum) {
 			fatal("checksum verification failed",
-				slog.Any("actual", actual.Sum(nil)), slog.Any("expected", expected.Sum(nil)))
+				slog.String("actual", hex.EncodeToString(actualSum)),
+				slog.String("expected", hex.EncodeToString(expectedSum)))
 		} else {
-			logger.Info("checksum verification succeeded", slog.Any("actual", actual.Sum(nil)))
+			logger.Info("checksum verification succeeded", slog.String("actual", hex.EncodeToString(actualSum)))
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Switches `zstdseek` console logging from JSON to the standard `slog` text handler. This keeps stderr readable for CLI users while preserving structured fields and the existing verbose/debug behavior.

Verification checksum fields are now encoded as hex strings so text output stays readable instead of printing escaped raw bytes.

This addresses the console-output part of #169.

## Validation

- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go test ./...` in `cmd/zstdseek`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go test ./...` in `pkg`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go run .`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go run . -f ../../README.md -o /tmp/codex-zstdseek-console.zst -t`