### PR TITLE
cmd: check stderr for progress output

### DIFF
--- a/cmd/zstdseek/main.go
+++ b/cmd/zstdseek/main.go
@@ -79,7 +79,7 @@ func main() {
 			fatal("failed to open input", slog.Any("error", err))
 		}
 
-		if term.IsTerminal(int(os.Stdout.Fd())) {
+		if term.IsTerminal(int(os.Stderr.Fd())) {
 			size := int64(-1)
 			stat, err := inputFile.Stat()
 			if err == nil {


### PR DESCRIPTION
## Summary

Changes `zstdseek` progress-bar TTY detection to check `os.Stderr` instead of `os.Stdout`.

Progress is status/console output, so tying it to stderr avoids suppressing progress just because compressed output is redirected through stdout.

This is a small follow-up to the CLI improvements tracked in #169.

## Validation

- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go test ./...` in `cmd/zstdseek`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go test ./...` in `pkg`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go run . -f ../../README.md -o /tmp/codex-zstdseek-stderr-tty.zst -t`