### PR TITLE
cmd: add chunk size shorthand

### DIFF
--- a/cmd/zstdseek/main.go
+++ b/cmd/zstdseek/main.go
@@ -45,6 +45,42 @@ func compressionConcurrency(threads, defaultConcurrency int) (int, bool) {
 	return threads, true
 }
 
+func parseChunkSizes(s string) (minSize, avgSize, maxSize int, err error) {
+	parse := func(s string) (int, error) {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return 0, err
+		}
+		return n, nil
+	}
+
+	chunkParams := strings.Split(s, ":")
+	switch len(chunkParams) {
+	case 1:
+		avg, err := parse(chunkParams[0])
+		if err != nil {
+			return 0, 0, 0, err
+		}
+		return avg / 4 * 1024, avg * 1024, avg * 4 * 1024, nil
+	case 3:
+		min, err := parse(chunkParams[0])
+		if err != nil {
+			return 0, 0, 0, err
+		}
+		avg, err := parse(chunkParams[1])
+		if err != nil {
+			return 0, 0, 0, err
+		}
+		max, err := parse(chunkParams[2])
+		if err != nil {
+			return 0, 0, 0, err
+		}
+		return min * 1024, avg * 1024, max * 1024, nil
+	default:
+		return 0, 0, 0, errors.New("expected N or min:avg:max")
+	}
+}
+
 func main() {
 	ctx := context.Background()
 	defaultConcurrency := runtime.GOMAXPROCS(0)
@@ -57,7 +93,7 @@ func main() {
 
 	flag.StringVar(&inputFlag, "f", "", "input filename")
 	flag.StringVar(&outputFlag, "o", "", "output filename")
-	flag.StringVar(&chunkingFlag, "c", "128:1024:8192", "min:avg:max chunking block size (in kb)")
+	flag.StringVar(&chunkingFlag, "c", "128:1024:8192", "avg or min:avg:max chunking block size (in kb)")
 	flag.BoolVar(&verifyFlag, "t", false, "test reading after the write")
 	flag.IntVar(&qualityFlag, "q", 1, "compression quality (lower == faster)")
 	flag.IntVar(&threadsFlag, "threads", defaultConcurrency, "number of concurrent compression workers (0 = runtime CPU count)")
@@ -135,20 +171,10 @@ func main() {
 		defer output.Close()
 	}
 
-	chunkParams := strings.Split(chunkingFlag, ":")
-	if len(chunkParams) != 3 {
-		fatal("failed parse chunker params. len() != 3", slog.Int("actual", len(chunkParams)))
+	minChunkSize, avgChunkSize, maxChunkSize, err := parseChunkSizes(chunkingFlag)
+	if err != nil {
+		fatal("failed to parse chunker params", slog.String("params", chunkingFlag), slog.Any("error", err))
 	}
-	mustConv := func(s string) int {
-		n, err := strconv.Atoi(s)
-		if err != nil {
-			fatal("failed to parse int", slog.String("string", s), slog.Any("error", err))
-		}
-		return n
-	}
-	minChunkSize := mustConv(chunkParams[0]) * 1024
-	avgChunkSize := mustConv(chunkParams[1]) * 1024
-	maxChunkSize := mustConv(chunkParams[2]) * 1024
 
 	var zstdOpts []zstd.EOption = []zstd.EOption{
 		zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(qualityFlag)),

--- a/cmd/zstdseek/main_test.go
+++ b/cmd/zstdseek/main_test.go
@@ -42,3 +42,70 @@ func TestCompressionConcurrency(t *testing.T) {
 		})
 	}
 }
+
+func TestParseChunkSizes(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantMin int
+		wantAvg int
+		wantMax int
+		wantErr bool
+	}{
+		{
+			name:    "explicit range",
+			in:      "128:1024:8192",
+			wantMin: 128 * 1024,
+			wantAvg: 1024 * 1024,
+			wantMax: 8192 * 1024,
+		},
+		{
+			name:    "average shorthand",
+			in:      "1024",
+			wantMin: 256 * 1024,
+			wantAvg: 1024 * 1024,
+			wantMax: 4096 * 1024,
+		},
+		{
+			name:    "average shorthand uses integer kb",
+			in:      "5",
+			wantMin: 1 * 1024,
+			wantAvg: 5 * 1024,
+			wantMax: 20 * 1024,
+		},
+		{
+			name:    "wrong field count",
+			in:      "128:1024",
+			wantErr: true,
+		},
+		{
+			name:    "invalid shorthand",
+			in:      "nope",
+			wantErr: true,
+		},
+		{
+			name:    "invalid range",
+			in:      "128:nope:8192",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMin, gotAvg, gotMax, err := parseChunkSizes(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("parseChunkSizes returned nil error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseChunkSizes returned error: %v", err)
+			}
+			if gotMin != tt.wantMin || gotAvg != tt.wantAvg || gotMax != tt.wantMax {
+				t.Fatalf("parseChunkSizes(%q) = (%d, %d, %d), want (%d, %d, %d)",
+					tt.in, gotMin, gotAvg, gotMax, tt.wantMin, tt.wantAvg, tt.wantMax)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `zstdseek -c N` as shorthand for `-c N/4:N:N*4`, while preserving the existing `-c min:avg:max` form.

The chunk-size parsing now lives in a small helper with focused tests for the shorthand, explicit ranges, and invalid input.

Refs https://github.com/SaveTheRbtz/zstd-seekable-format-go/issues/169

## Validation

- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go test ./...` in `cmd/zstdseek`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go test ./...` in `pkg`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go run . -c 1024 -f ../../README.md -o /tmp/codex-zstdseek-chunk-short.zst -t`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go run . -c 128:1024:8192 -f ../../README.md -o /tmp/codex-zstdseek-chunk-range.zst -t`