### PR TITLE
cmd: default to stdin and stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,14 @@ zstdseek -f input.dat -o input.dat.zst -t
 ```
 
 Use `-` for stdin or stdout. Verification requires a named output file.
+When `-f` or `-o` is omitted, `zstdseek` uses stdin or stdout respectively.
+To avoid dumping compressed bytes to a terminal, stdout output is rejected when
+stdout is a terminal.
 
 ```sh
 zstdseek -f - -o input.dat.zst < input.dat
 zstdseek -f input.dat -o - > input.dat.zst
+zstdseek < input.dat > input.dat.zst
 ```
 
 The main tuning flags are `-q` for Zstandard compression quality and `-c` for

--- a/cmd/zstdseek/main.go
+++ b/cmd/zstdseek/main.go
@@ -81,6 +81,24 @@ func parseChunkSizes(s string) (minSize, avgSize, maxSize int, err error) {
 	}
 }
 
+func resolveInputOutput(inputFlag, outputFlag string, verify, stdoutIsTerminal bool) (inputName, outputName string, err error) {
+	if inputFlag == "" {
+		inputFlag = "-"
+	}
+	if outputFlag == "" {
+		outputFlag = "-"
+	}
+	if outputFlag == "-" {
+		if verify {
+			return "", "", errors.New("verify can't be used with stdout output")
+		}
+		if stdoutIsTerminal {
+			return "", "", errors.New("refusing to write compressed data to terminal; use -o or redirect stdout")
+		}
+	}
+	return inputFlag, outputFlag, nil
+}
+
 func main() {
 	ctx := context.Background()
 	defaultConcurrency := runtime.GOMAXPROCS(0)
@@ -91,8 +109,8 @@ func main() {
 		verifyFlag, verboseFlag             bool
 	)
 
-	flag.StringVar(&inputFlag, "f", "", "input filename")
-	flag.StringVar(&outputFlag, "o", "", "output filename")
+	flag.StringVar(&inputFlag, "f", "", "input filename (default: stdin)")
+	flag.StringVar(&outputFlag, "o", "", "output filename (default: stdout)")
 	flag.StringVar(&chunkingFlag, "c", "128:1024:8192", "avg or min:avg:max chunking block size (in kb)")
 	flag.BoolVar(&verifyFlag, "t", false, "test reading after the write")
 	flag.IntVar(&qualityFlag, "q", 1, "compression quality (lower == faster)")
@@ -109,11 +127,9 @@ func main() {
 	}
 	seekableLogger := logger.WithGroup("seekable")
 
-	if inputFlag == "" || outputFlag == "" {
-		fatal("both input and output files need to be defined")
-	}
-	if verifyFlag && outputFlag == "-" {
-		fatal("verify can't be used with stdout output")
+	inputName, outputName, err := resolveInputOutput(inputFlag, outputFlag, verifyFlag, term.IsTerminal(int(os.Stdout.Fd())))
+	if err != nil {
+		fatal("invalid input/output options", slog.Any("error", err))
 	}
 	concurrency, ok := compressionConcurrency(threadsFlag, defaultConcurrency)
 	if !ok {
@@ -123,8 +139,8 @@ func main() {
 	bar := progressbar.DefaultSilent(0, "")
 
 	inputFile := os.Stdin
-	if inputFlag != "-" {
-		if inputFile, err = os.Open(inputFlag); err != nil {
+	if inputName != "-" {
+		if inputFile, err = os.Open(inputName); err != nil {
 			fatal("failed to open input", slog.Any("error", err))
 		}
 
@@ -163,8 +179,8 @@ func main() {
 	}
 
 	output := os.Stdout
-	if outputFlag != "-" {
-		output, err = os.OpenFile(outputFlag, os.O_TRUNC|os.O_WRONLY|os.O_CREATE, 0o644)
+	if outputName != "-" {
+		output, err = os.OpenFile(outputName, os.O_TRUNC|os.O_WRONLY|os.O_CREATE, 0o644)
 		if err != nil {
 			fatal("failed to open output", slog.Any("error", err))
 		}
@@ -233,7 +249,7 @@ func main() {
 	if verifyFlag {
 		logger.Info("verifying checksum")
 
-		verify, err := os.Open(outputFlag)
+		verify, err := os.Open(outputName)
 		if err != nil {
 			fatal("failed to open file for verification", slog.Any("error", err))
 		}

--- a/cmd/zstdseek/main_test.go
+++ b/cmd/zstdseek/main_test.go
@@ -109,3 +109,72 @@ func TestParseChunkSizes(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveInputOutput(t *testing.T) {
+	tests := []struct {
+		name             string
+		inputFlag        string
+		outputFlag       string
+		verify           bool
+		stdoutIsTerminal bool
+		wantInput        string
+		wantOutput       string
+		wantErr          bool
+	}{
+		{
+			name:       "defaults to stdin stdout",
+			wantInput:  "-",
+			wantOutput: "-",
+		},
+		{
+			name:             "refuses implicit terminal stdout",
+			stdoutIsTerminal: true,
+			wantErr:          true,
+		},
+		{
+			name:             "allows file output when stdout is terminal",
+			outputFlag:       "out.zst",
+			stdoutIsTerminal: true,
+			wantInput:        "-",
+			wantOutput:       "out.zst",
+		},
+		{
+			name:       "preserves explicit input and output",
+			inputFlag:  "in.dat",
+			outputFlag: "out.zst",
+			wantInput:  "in.dat",
+			wantOutput: "out.zst",
+		},
+		{
+			name:       "verify requires file output",
+			outputFlag: "-",
+			verify:     true,
+			wantErr:    true,
+		},
+		{
+			name:             "refuses explicit terminal stdout",
+			outputFlag:       "-",
+			stdoutIsTerminal: true,
+			wantErr:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotInput, gotOutput, err := resolveInputOutput(tt.inputFlag, tt.outputFlag, tt.verify, tt.stdoutIsTerminal)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("resolveInputOutput returned nil error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveInputOutput returned error: %v", err)
+			}
+			if gotInput != tt.wantInput || gotOutput != tt.wantOutput {
+				t.Fatalf("resolveInputOutput returned (%q, %q), want (%q, %q)",
+					gotInput, gotOutput, tt.wantInput, tt.wantOutput)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Makes `zstdseek` behave more like common compression tools when input or output flags are omitted:

- omitted `-f` reads from stdin
- omitted `-o` writes to stdout
- `-t` still requires a named output file
- stdout output is refused when stdout is a terminal, including explicit `-o -`, to avoid dumping compressed bytes into the console

The README and flag help now document the defaults, and the input/output resolution is covered with focused tests.

Refs https://github.com/SaveTheRbtz/zstd-seekable-format-go/issues/169

## Validation

- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go test ./...` in `cmd/zstdseek`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go test ./...` in `pkg`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go run . -o /tmp/codex-zstdseek-default-input.zst -t < ../../README.md`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go run . -f ../../README.md > /tmp/codex-zstdseek-default-output.zst`
- `env GOCACHE=/tmp/codex-go-build-cache GOMODCACHE=/tmp/codex-gomodcache go run . -t < ../../README.md > /tmp/codex-zstdseek-verify-stdout.zst` failed as expected with the verify/stdout error