### PR TITLE
ci: test minimum, stable, and tip Go

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.25.0', '1.26.3']
+        go-version: ['1.25.0', 'stable', 'tip']
         dir: ['pkg', 'cmd/zstdseek']
     env:
       GOTOOLCHAIN: local
@@ -25,8 +25,15 @@ jobs:
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ matrix.go-version == 'tip' && 'stable' || matrix.go-version }}
           cache-dependency-path: ${{ matrix.dir }}/go.sum
+      - name: Setup Go tip
+        if: matrix.go-version == 'tip'
+        run: |
+          go install golang.org/dl/gotip@latest
+          GOTIP="$(go env GOPATH)/bin/gotip"
+          "$GOTIP" download
+          echo "$("$GOTIP" env GOROOT)/bin" >> "$GITHUB_PATH"
       - name: Display Go version
         run: go version
       - name: Install dependencies (${{ matrix.dir }})


### PR DESCRIPTION
## Summary

- test both Go modules with the minimum supported Go 1.25.0 toolchain
- track the current stable Go release without a patch-version pin
- build and test against Go tip using the official `gotip` bootstrap

## Why

This keeps minimum-version compatibility covered while detecting issues in both the current stable release and the next Go release during development.

## Validation

- `go test ./...` in `pkg`
- `go test ./...` in `cmd/zstdseek`
- parsed `.github/workflows/go.yml` as YAML
- `git diff --check`