### PR TITLE
cmd: upgrade fastcdc-go to v0.4.0

### DIFF
--- a/cmd/zstdseek/go.mod
+++ b/cmd/zstdseek/go.mod
@@ -3,7 +3,7 @@ module github.com/SaveTheRbtz/zstd-seekable-format-go/cmd/zstdseek
 go 1.25.0
 
 require (
-	github.com/SaveTheRbtz/fastcdc-go v0.3.0
+	github.com/SaveTheRbtz/fastcdc-go v0.4.0
 	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0
 	github.com/klauspost/compress v1.19.1
 	github.com/schollz/progressbar/v3 v3.19.1

--- a/cmd/zstdseek/go.sum
+++ b/cmd/zstdseek/go.sum
@@ -1,5 +1,5 @@
-github.com/SaveTheRbtz/fastcdc-go v0.3.0 h1:JdHvLlnijDuisYIwpRDcHZEjbxvCqtEmJ3gf35VJBgA=
-github.com/SaveTheRbtz/fastcdc-go v0.3.0/go.mod h1:2kMKqvBv1h9wCaUfETqsVkSESsCiFhp4YyEHyz7/SfE=
+github.com/SaveTheRbtz/fastcdc-go v0.4.0 h1:T5egtVeOnQgFuU2CymrRkPOu0vgDuEwuAt5YAL/A41o=
+github.com/SaveTheRbtz/fastcdc-go v0.4.0/go.mod h1:kFkPuGmiQa9oGwHIgJV4sKfmVBNNuCCCz47P4J0aXSQ=
 github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0 h1:LvK7+C6qgz8BPnmn7xGekf8vTkcqTvyBBHaLYIMxx0g=
 github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0/go.mod h1:I28hc9eaiqKCoOB+9Wh/P1IOScfm0xCgyWC6DAo0lmo=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/cmd/zstdseek/main.go
+++ b/cmd/zstdseek/main.go
@@ -206,30 +206,31 @@ func main() {
 	}
 	defer w.Close()
 
-	// convert average chunk size to a number of bits
-	logger.Debug("setting chunker params", slog.Int("min", minChunkSize), slog.Int("max", maxChunkSize))
-	chunker, err := fastcdc.NewChunker(
-		input,
-		fastcdc.Options{
-			MinSize:     minChunkSize,
-			AverageSize: avgChunkSize,
-			MaxSize:     maxChunkSize,
-		},
+	logger.Debug("setting chunker params",
+		slog.Int("min", minChunkSize),
+		slog.Int("average", avgChunkSize),
+		slog.Int("max", maxChunkSize),
 	)
+	chunker, err := fastcdc.New(fastcdc.Config{
+		MinSize:     minChunkSize,
+		AverageSize: avgChunkSize,
+		MaxSize:     maxChunkSize,
+	})
 	if err != nil {
 		fatal("failed to create chunker", slog.Any("error", err))
 	}
+	chunkReader := chunker.NewReader(input)
 
 	frameSource := func() ([]byte, error) {
-		chunk, err := chunker.Next()
+		chunk, err := chunkReader.Next()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil, nil
 			}
 			return nil, err
 		}
-		// Chunker invalidates the data after calling Next, so we need to clone it
-		return bytes.Clone(chunk.Data), nil
+		// Reader invalidates the data after calling Next, so we need to clone it.
+		return bytes.Clone(chunk), nil
 	}
 
 	err = w.WriteMany(ctx, frameSource,


### PR DESCRIPTION
## Summary

- upgrade the `zstdseek` command from fastcdc-go v0.3.0 to v0.4.0
- migrate from the removed `NewChunker`/`Options`/`Chunk` API to `New`/`Config`/`Reader`
- retain cloning of borrowed chunk data before handing it to concurrent compression workers

## Why

fastcdc-go v0.4.0 replaces the legacy chunker with the FastCDC 2020 algorithm and canonical Gear table. Its smaller API separates the immutable chunking configuration from per-stream readers, so the command must migrate to compile against the new release.

This intentionally changes content-defined chunk boundaries. Producers that require identical boundaries must use the same fastcdc-go version and configuration.

## Impact

The command keeps its existing `-c` min/average/max interface and streaming behavior while using fastcdc-go v0.4.0. Existing archives remain readable; newly produced frame boundaries may differ because of the new algorithm.

## Validation

- `go test ./...` in `cmd/zstdseek`
- end-to-end compression and `-t` checksum verification of `linux-v5.15.tar` (1.1 GiB)
  - compressed output: 199 MiB
  - verified SHA-512/256: `4533c09e0497a2cfeb3e3578ef64e25e6261adfd4bc98abc195341018d04d685`
