### PR TITLE
ci: add govulncheck for both Go modules

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,34 @@
+name: govulncheck
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '23 9 * * 3'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dir: ['pkg', 'cmd/zstdseek']
+    env:
+      GOTOOLCHAIN: local
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6
+        with:
+          go-version: stable
+          check-latest: true
+          cache-dependency-path: ${{ matrix.dir }}/go.sum
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Scan for vulnerabilities (${{ matrix.dir }})
+        working-directory: ./${{ matrix.dir }}
+        run: govulncheck -test ./...


### PR DESCRIPTION
Adds a dedicated `govulncheck` workflow to detect known vulnerabilities reachable from either Go module. It runs on pull requests, pushes to `main`, a weekly schedule, and manual dispatch, so new advisories can be detected even when dependencies have not changed.

Each module is scanned with `govulncheck -test ./...` on the latest stable Go release. Including tests covers the library's concrete Zstandard implementation in tests and examples. The workflow uses the existing pinned checkout/setup-go actions, read-only repository permissions, and default text output so findings fail the job.

Validation:
- `actionlint .github/workflows/govulncheck.yml` passed.
- `govulncheck -test ./...` passed in `pkg` and `cmd/zstdseek`: no vulnerabilities found (local Go 1.27.0).
- Staged diff whitespace check passed.
